### PR TITLE
Remove redundant registration of shutdown hook. Fixes #11

### DIFF
--- a/src/main/java/com/coinblesk/server/service/WalletService.java
+++ b/src/main/java/com/coinblesk/server/service/WalletService.java
@@ -152,7 +152,6 @@ public class WalletService {
 
         blockChain.addWallet(wallet);
         peerGroup.addWallet(wallet);
-        installShutdownHook();
         peerGroup.start();
         final DownloadProgressTracker listener = new DownloadProgressTracker() {
             @Override
@@ -338,15 +337,6 @@ public class WalletService {
         } catch (Exception e) {
             LOG.error("cannot shutdown wallet in shutdown", e);
         }
-    }
-
-    private void installShutdownHook(/*final PeerGroup peerGroup, final BlockStore blockStore, 
-            final Wallet wallet*/) {
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override public void run() {
-                shutdown();
-            }
-        });
     }
 
     public PeerGroup peerGroup() {


### PR DESCRIPTION
This fixes #11 

The javax `@PreDestroy` annotation already registers the `shutdown()` hook. The explicit second registration caused `shutdown()` to be called twice from different threads during shutdown. This caused `peerGroup.stop()` to hang, possibly due to a deadlock.

Since I cannot reproduce the bug reliably,  it would be nice if someone could check if this works. Shutdown is now <15s whereas it was over one minute before in some cases.