### PR TITLE
Fix VersionController reading correct manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,14 @@ springBoot {
     executable = true
 }
 
+jar {
+    manifest {
+        attributes(
+                'Version': project.version
+        )
+    }
+}
+
 dependencies {
     // Spring Boot
     compile 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/coinblesk/server/controller/VersionController.java
+++ b/src/main/java/com/coinblesk/server/controller/VersionController.java
@@ -102,7 +102,7 @@ public class VersionController {
 	/**
 	 * Extracts the Version property from the manifest.
 	 * 
-	 * @return the version iff run as war packaged application. Otherwise, (UNKNOWN) is returned.
+	 * @return the version iff run as jar packaged application. Otherwise, (UNKNOWN) is returned.
 	 * @throws CoinbleskException
 	 */
 	private String getServerVersion() throws CoinbleskException {
@@ -111,9 +111,9 @@ public class VersionController {
     	final String defaultVersion = "(UNKNOWN)";
     	InputStream inputStream = null;
 		try {
-			inputStream = context.getResourceAsStream("/META-INF/MANIFEST.MF");
+			inputStream = context.getClassLoader().getResourceAsStream("/META-INF/MANIFEST.MF");
 			if (inputStream == null) {
-				LOG.warn("Manifest resource not found (inputStream=null, maybe not run as war file?).");
+				LOG.warn("Manifest resource not found (inputStream=null, maybe not run as jar file?).");
 				return defaultVersion;
 			}
 			


### PR DESCRIPTION
When running as executable jar, the class loader has to be used
in order to get the MANIFEST.MF file. Since the server version is
only used when logging we could probably get rid of this anyway.