### PR TITLE
Remove short rest interfaces & Formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+trim_trailing_whitespace = true

--- a/src/main/java/com/coinblesk/server/Application.java
+++ b/src/main/java/com/coinblesk/server/Application.java
@@ -4,9 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class Application
-{
-    public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
-    }
+public class Application {
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
 }

--- a/src/main/java/com/coinblesk/server/auth/Http401UnauthorizedEntryPoint.java
+++ b/src/main/java/com/coinblesk/server/auth/Http401UnauthorizedEntryPoint.java
@@ -1,15 +1,16 @@
 package com.coinblesk.server.auth;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 /**
  * Returns a 401 error code (Unauthorized) to the client.
@@ -17,18 +18,17 @@ import java.io.IOException;
 @Component
 public class Http401UnauthorizedEntryPoint implements AuthenticationEntryPoint {
 
-    private final Logger log = LoggerFactory.getLogger(Http401UnauthorizedEntryPoint.class);
+	private final Logger log = LoggerFactory.getLogger(Http401UnauthorizedEntryPoint.class);
 
-    /**
-     * Always returns a 401 error code to the client.
-     */
-    @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException arg2)
-        throws IOException,
-            ServletException {
+	/**
+	 * Always returns a 401 error code to the client.
+	 */
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException arg2)
+			throws IOException, ServletException {
 
-        log.debug("Pre-authenticated entry point called. Rejecting access");
-        response.setHeader("WWW-Authenticate", "Bearer token_type=\"JWT\"");
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access denied");
-    }
+		log.debug("Pre-authenticated entry point called. Rejecting access");
+		response.setHeader("WWW-Authenticate", "Bearer token_type=\"JWT\"");
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access denied");
+	}
 }

--- a/src/main/java/com/coinblesk/server/auth/JWTConfigurer.java
+++ b/src/main/java/com/coinblesk/server/auth/JWTConfigurer.java
@@ -7,17 +7,17 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 public class JWTConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
-    public final static String AUTHORIZATION_HEADER = "Authorization";
+	public final static String AUTHORIZATION_HEADER = "Authorization";
 
-    private TokenProvider tokenProvider;
+	private TokenProvider tokenProvider;
 
-    public JWTConfigurer(TokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
-    }
+	public JWTConfigurer(TokenProvider tokenProvider) {
+		this.tokenProvider = tokenProvider;
+	}
 
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
-        JWTFilter customFilter = new JWTFilter(tokenProvider);
-        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
-    }
+	@Override
+	public void configure(HttpSecurity http) throws Exception {
+		JWTFilter customFilter = new JWTFilter(tokenProvider);
+		http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+	}
 }

--- a/src/main/java/com/coinblesk/server/auth/JWTFilter.java
+++ b/src/main/java/com/coinblesk/server/auth/JWTFilter.java
@@ -1,12 +1,6 @@
 package com.coinblesk.server.auth;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.GenericFilterBean;
+import java.io.IOException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -14,50 +8,56 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import io.jsonwebtoken.ExpiredJwtException;
 
 /**
- * Filters incoming requests and installs a Spring Security principal if a header corresponding to a valid user is
- * found.
+ * Filters incoming requests and installs a Spring Security principal if a
+ * header corresponding to a valid user is found.
  */
 public class JWTFilter extends GenericFilterBean {
 
-    private final Logger log = LoggerFactory.getLogger(JWTFilter.class);
+	private final Logger log = LoggerFactory.getLogger(JWTFilter.class);
 
-    private TokenProvider tokenProvider;
+	private TokenProvider tokenProvider;
 
-    public JWTFilter(TokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
-    }
+	public JWTFilter(TokenProvider tokenProvider) {
+		this.tokenProvider = tokenProvider;
+	}
 
-    @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
-        throws IOException, ServletException {
-        try {
-            HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-            String jwt = resolveToken(httpServletRequest);
-            if (StringUtils.hasText(jwt)) {
-                if (this.tokenProvider.validateToken(jwt)) {
-                    Authentication authentication = this.tokenProvider.getAuthentication(jwt);
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
-            }
-            filterChain.doFilter(servletRequest, servletResponse);
-        } catch (ExpiredJwtException eje) {
-            log.info("Security exception for user {} - {}", eje.getClaims().getSubject(), eje.getMessage());
-            HttpServletResponse reponse = (HttpServletResponse)servletResponse;
-            reponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired (" + eje.getMessage() + ")");
-        }
-    }
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+			throws IOException, ServletException {
+		try {
+			HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+			String jwt = resolveToken(httpServletRequest);
+			if (StringUtils.hasText(jwt)) {
+				if (this.tokenProvider.validateToken(jwt)) {
+					Authentication authentication = this.tokenProvider.getAuthentication(jwt);
+					SecurityContextHolder.getContext().setAuthentication(authentication);
+				}
+			}
+			filterChain.doFilter(servletRequest, servletResponse);
+		} catch (ExpiredJwtException eje) {
+			log.info("Security exception for user {} - {}", eje.getClaims().getSubject(), eje.getMessage());
+			HttpServletResponse reponse = (HttpServletResponse) servletResponse;
+			reponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired (" + eje.getMessage() + ")");
+		}
+	}
 
-    private String resolveToken(HttpServletRequest request){
-        String bearerToken = request.getHeader(JWTConfigurer.AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            String jwt = bearerToken.substring(7, bearerToken.length());
-            return jwt;
-        }
-        return null;
-    }
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(JWTConfigurer.AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			String jwt = bearerToken.substring(7, bearerToken.length());
+			return jwt;
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/coinblesk/server/auth/TokenProvider.java
+++ b/src/main/java/com/coinblesk/server/auth/TokenProvider.java
@@ -63,12 +63,13 @@ public class TokenProvider {
 			validity = new Date(now + this.tokenValidityInMilliseconds);
 		}
 
-		return Jwts	.builder()
-					.setSubject(authentication.getName())
-					.claim(AUTHORITIES_KEY, authorities)
-					.signWith(SignatureAlgorithm.HS256, secretKey)
-					.setExpiration(validity)
-					.compact();
+		return Jwts
+				.builder()
+				.setSubject(authentication.getName())
+				.claim(AUTHORITIES_KEY, authorities)
+				.signWith(SignatureAlgorithm.HS256, secretKey)
+				.setExpiration(validity)
+				.compact();
 	}
 
 	public Authentication getAuthentication(String token) {

--- a/src/main/java/com/coinblesk/server/auth/TokenProvider.java
+++ b/src/main/java/com/coinblesk/server/auth/TokenProvider.java
@@ -1,11 +1,12 @@
 package com.coinblesk.server.auth;
 
-import com.coinblesk.server.config.AppConfig;
-import com.coinblesk.server.config.UserRole;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SignatureException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,81 +17,83 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.stream.Collectors;
+import com.coinblesk.server.config.AppConfig;
+import com.coinblesk.server.config.UserRole;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
 
 @Component
 public class TokenProvider {
 
-    private final Logger log = LoggerFactory.getLogger(TokenProvider.class);
+	private final Logger log = LoggerFactory.getLogger(TokenProvider.class);
 
-    private static final String AUTHORITIES_KEY = "auth";
+	private static final String AUTHORITIES_KEY = "auth";
 
-    private byte[] secretKey;
+	private byte[] secretKey;
 
-    private long tokenValidityInMilliseconds;
+	private long tokenValidityInMilliseconds;
 
-    private long adminTokenValidityInMilliseconds;
+	private long adminTokenValidityInMilliseconds;
 
-    @Autowired
-    private AppConfig appConfig;
+	@Autowired
+	private AppConfig appConfig;
 
-    @PostConstruct
-    public void init() {
-        if (appConfig.getJwtSecret().trim().equals(""))
-            throw new RuntimeException("JWT secret must be set no non empty string");
-        this.secretKey = appConfig.getJwtSecret().getBytes();
-        this.tokenValidityInMilliseconds = appConfig.getJwtValidityInSeconds() * 1000;
-        this.adminTokenValidityInMilliseconds = appConfig.getJwtAdminValidityInSeconds() * 1000;
-    }
+	@PostConstruct
+	public void init() {
+		if (appConfig.getJwtSecret().trim().equals(""))
+			throw new RuntimeException("JWT secret must be set no non empty string");
+		this.secretKey = appConfig.getJwtSecret().getBytes();
+		this.tokenValidityInMilliseconds = appConfig.getJwtValidityInSeconds() * 1000;
+		this.adminTokenValidityInMilliseconds = appConfig.getJwtAdminValidityInSeconds() * 1000;
+	}
 
-    public String createToken(Authentication authentication) {
-        String authorities = authentication.getAuthorities().stream()
-            .map(GrantedAuthority::getAuthority)
-            .collect(Collectors.joining(","));
+	public String createToken(Authentication authentication) {
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
 
-        long now = (new Date()).getTime();
-        Date validity;
-        if (authentication.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.ADMIN.getAuthority()))) {
-            validity = new Date(now + this.adminTokenValidityInMilliseconds);
-        } else {
-            validity = new Date(now + this.tokenValidityInMilliseconds);
-        }
+		long now = (new Date()).getTime();
+		Date validity;
+		if (authentication.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.ADMIN.getAuthority()))) {
+			validity = new Date(now + this.adminTokenValidityInMilliseconds);
+		} else {
+			validity = new Date(now + this.tokenValidityInMilliseconds);
+		}
 
-        return Jwts.builder()
-            .setSubject(authentication.getName())
-            .claim(AUTHORITIES_KEY, authorities)
-            .signWith(SignatureAlgorithm.HS256, secretKey)
-            .setExpiration(validity)
-            .compact();
-    }
+		return Jwts	.builder()
+					.setSubject(authentication.getName())
+					.claim(AUTHORITIES_KEY, authorities)
+					.signWith(SignatureAlgorithm.HS256, secretKey)
+					.setExpiration(validity)
+					.compact();
+	}
 
-    public Authentication getAuthentication(String token) {
-        Claims claims = Jwts.parser()
-            .setSigningKey(secretKey)
-            .parseClaimsJws(token)
-            .getBody();
+	public Authentication getAuthentication(String token) {
+		Claims claims = Jwts.parser()
+			.setSigningKey(secretKey)
+			.parseClaimsJws(token)
+			.getBody();
 
-        Collection<? extends GrantedAuthority> authorities =
-            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
 
-        User principal = new User(claims.getSubject(), "", authorities);
+		User principal = new User(claims.getSubject(), "", authorities);
 
-        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
-    }
+		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+	}
 
-    public boolean validateToken(String authToken) {
-        try {
-            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(authToken);
-            return true;
-        } catch (SignatureException e) {
-            log.info("Invalid JWT signature: " + e.getMessage());
-            return false;
-        }
-    }
+	public boolean validateToken(String authToken) {
+		try {
+			Jwts.parser().setSigningKey(secretKey).parseClaimsJws(authToken);
+			return true;
+		} catch (SignatureException e) {
+			log.info("Invalid JWT signature: " + e.getMessage());
+			return false;
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/auth/UserDetailsService.java
+++ b/src/main/java/com/coinblesk/server/auth/UserDetailsService.java
@@ -1,7 +1,12 @@
 package com.coinblesk.server.auth;
 
-import com.coinblesk.server.dao.UserAccountRepository;
-import com.coinblesk.server.entity.UserAccount;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,47 +17,44 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
-import javax.transaction.Transactional;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
+import com.coinblesk.server.dao.UserAccountRepository;
+import com.coinblesk.server.entity.UserAccount;
 
 @Component
-public class UserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService{
+public class UserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService {
 
-    private final Logger log = LoggerFactory.getLogger(UserDetailsService.class);
+	private final Logger log = LoggerFactory.getLogger(UserDetailsService.class);
 
-    @Autowired
-    private UserAccountRepository userAccountRepository;
+	@Autowired
+	private UserAccountRepository userAccountRepository;
 
-    @Override
-    @Transactional
-    public UserDetails loadUserByUsername(final String login) {
-        log.debug("Authenticating {}", login);
-        String lowercaseLogin = login.toLowerCase(Locale.ENGLISH);
-        Optional<UserAccount> userFromDatabase = userAccountRepository.findOptionalByEmail(lowercaseLogin);
-        return userFromDatabase.map(user -> {
+	@Override
+	@Transactional
+	public UserDetails loadUserByUsername(final String login) {
+		log.debug("Authenticating {}", login);
+		String lowercaseLogin = login.toLowerCase(Locale.ENGLISH);
+		Optional<UserAccount> userFromDatabase = userAccountRepository.findOptionalByEmail(lowercaseLogin);
+		return userFromDatabase.map(user -> {
 
-            // Check for deletion
-            if (user.isDeleted()) {
-                throw new AuthenticationServiceException("Account not active");
-            }
+			// Check for deletion
+			if (user.isDeleted()) {
+				throw new AuthenticationServiceException("Account not active");
+			}
 
-            // Check for email verification
-            if (!user.isEmailVerified()) {
-                throw new AuthenticationServiceException("Email for user " + lowercaseLogin + " not verified yet");
-            }
+			// Check for email verification
+			if (!user.isEmailVerified()) {
+				throw new AuthenticationServiceException("Email for user " + lowercaseLogin + " not verified yet");
+			}
 
-            // Populate authority list
-            List<GrantedAuthority> grantedAuthorities = Collections.singletonList(
-                    new SimpleGrantedAuthority(user.getUserRole().getAuthority()));
+			// Populate authority list
+			List<GrantedAuthority> grantedAuthorities = Collections.singletonList(
+					new SimpleGrantedAuthority(user.getUserRole().getAuthority()));
 
-            return new org.springframework.security.core.userdetails.User(lowercaseLogin,
-                    user.getPassword(),
-                    grantedAuthorities);
-        }).orElseThrow(() -> new UsernameNotFoundException("User " + lowercaseLogin + " was not found in the " +
-                "database"));
-    }
+			return new org.springframework.security.core.userdetails.User(lowercaseLogin,
+					user.getPassword(),
+					grantedAuthorities);
+			}).orElseThrow(() -> new UsernameNotFoundException("User " + lowercaseLogin + " was not found in the " +
+					"database"));
+	}
 
 }

--- a/src/main/java/com/coinblesk/server/config/AppConfig.java
+++ b/src/main/java/com/coinblesk/server/config/AppConfig.java
@@ -15,24 +15,24 @@
  */
 package com.coinblesk.server.config;
 
+import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
 
+import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResource;
 
 import com.coinblesk.bitcoin.BitcoinNet;
 import com.coinblesk.server.utils.CoinUtils;
-import java.math.BigInteger;
-import org.bitcoinj.core.ECKey;
-import org.slf4j.LoggerFactory;
 
 /**
- * This is the default configuration for testcases. If you want to change these settings e.g. when using
- * tomcat, add these values to context.xml:
+ * This is the default configuration for testcases. If you want to change these
+ * settings e.g. when using tomcat, add these values to context.xml:
  *
  * <pre>
  *  ...
@@ -45,106 +45,107 @@ import org.slf4j.LoggerFactory;
  */
 @Configuration
 public class AppConfig {
-    
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(AppConfig.class);
-    
-    private final static Set<String> SUPPORTED_CLIENT_VERSIONS;
+
+	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(AppConfig.class);
+
+	private final static Set<String> SUPPORTED_CLIENT_VERSIONS;
 	static {
 		SUPPORTED_CLIENT_VERSIONS = new HashSet<>();
-		//SUPPORTED_CLIENT_VERSIONS.add("1.0"); // CeBIT release (v1.0.262, should be v2.1)
-		//SUPPORTED_CLIENT_VERSIONS.add("2.2"); // CLTV release
-                SUPPORTED_CLIENT_VERSIONS.add("2.3"); // TO versioning release
+		// SUPPORTED_CLIENT_VERSIONS.add("1.0"); // CeBIT release (v1.0.262,
+		// should be v2.1)
+		// SUPPORTED_CLIENT_VERSIONS.add("2.2"); // CLTV release
+		SUPPORTED_CLIENT_VERSIONS.add("2.3"); // TO versioning release
 	}
 
 	@Value("${coinblesk.url}")
-    private String url;
+	private String url;
 
-    @Value("${coinblesk.config.dir}")
-    private FileSystemResource configDir;
+	@Value("${coinblesk.config.dir}")
+	private FileSystemResource configDir;
 
-    @Value("${bitcoin.net}")
-    private String bitcoinNet;
+	@Value("${bitcoin.net}")
+	private String bitcoinNet;
 
-    @Value("${bitcoin.firstSeedNode}")
-    private String firstSeedNode;
+	@Value("${bitcoin.firstSeedNode}")
+	private String firstSeedNode;
 
-    @Value("${bitcoin.minconf}")
-    private int minConf;
+	@Value("${bitcoin.minconf}")
+	private int minConf;
 
-    @Value("${security.jwt.secret}")
-    private String jwtSecret;
+	@Value("${security.jwt.secret}")
+	private String jwtSecret;
 
-    @Value("${security.jwt.validityInSeconds}")
-    private Long jwtValidityInSeconds;
+	@Value("${security.jwt.validityInSeconds}")
+	private Long jwtValidityInSeconds;
 
-    @Value("${security.jwt.adminValidityInSeconds}")
-    private Long jwtAdminValidityInSeconds;
+	@Value("${security.jwt.adminValidityInSeconds}")
+	private Long jwtAdminValidityInSeconds;
 
-    //this private key is just use for unit tests
-    @Value("${bitcoin.potprivkey}")
-    private BigInteger potPrivateKeyAddress;
+	// this private key is just use for unit tests
+	@Value("${bitcoin.potprivkey}")
+	private BigInteger potPrivateKeyAddress;
 
-    @Value("${bitcoin.potCreationTime}")
-    private Long potCreationTime;
+	@Value("${bitcoin.potCreationTime}")
+	private Long potCreationTime;
 
-    static {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    }
-    
-    public FileSystemResource getConfigDir() {
-        return configDir;
-    }
+	static {
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+	}
 
-    public BitcoinNet getBitcoinNet() {
-        return BitcoinNet.of(bitcoinNet);
-    }
+	public FileSystemResource getConfigDir() {
+		return configDir;
+	}
 
-    public NetworkParameters getNetworkParameters() {
-        return CoinUtils.getNetworkParams(getBitcoinNet());
-    }
+	public BitcoinNet getBitcoinNet() {
+		return BitcoinNet.of(bitcoinNet);
+	}
 
-    public int getMinConf() {
-        return minConf;
-    }
-    
-    public Set<String> getSupportedClientVersions() {
-    	return new HashSet<>(SUPPORTED_CLIENT_VERSIONS);
-    }
-    
-    public ECKey getPotPrivateKeyAddress() {
-        
-        if(potPrivateKeyAddress == null || potPrivateKeyAddress.equals("")) {
-            ECKey ecKey = new ECKey();
-            LOG.error("No private key defined, cannot continue, suggested key:{}", ecKey.getPrivKey());
-            throw new RuntimeException("No private key defined, cannot continue, suggested key:" + ecKey.getPrivKey());
-        }
-        
-        ECKey ecKey = ECKey.fromPrivate(potPrivateKeyAddress);
-        LOG.info("Pot address is: {}", ecKey.toAddress(getNetworkParameters()));
-        return ecKey;
-    }
+	public NetworkParameters getNetworkParameters() {
+		return CoinUtils.getNetworkParams(getBitcoinNet());
+	}
 
-    public String getUrl() {
-        return url;
-    }
+	public int getMinConf() {
+		return minConf;
+	}
 
-    public String getJwtSecret() {
-        return jwtSecret;
-    }
+	public Set<String> getSupportedClientVersions() {
+		return new HashSet<>(SUPPORTED_CLIENT_VERSIONS);
+	}
 
-    public Long getJwtValidityInSeconds() {
-        return jwtValidityInSeconds;
-    }
+	public ECKey getPotPrivateKeyAddress() {
 
-    public Long getJwtAdminValidityInSeconds() {
-        return jwtAdminValidityInSeconds;
-    }
+		if (potPrivateKeyAddress == null || potPrivateKeyAddress.equals("")) {
+			ECKey ecKey = new ECKey();
+			LOG.error("No private key defined, cannot continue, suggested key:{}", ecKey.getPrivKey());
+			throw new RuntimeException("No private key defined, cannot continue, suggested key:" + ecKey.getPrivKey());
+		}
 
-    public Long getPotCreationTime() {
-        return potCreationTime;
-    }
+		ECKey ecKey = ECKey.fromPrivate(potPrivateKeyAddress);
+		LOG.info("Pot address is: {}", ecKey.toAddress(getNetworkParameters()));
+		return ecKey;
+	}
 
-    public String getFirstSeedNode() {
-        return firstSeedNode;
-    }
+	public String getUrl() {
+		return url;
+	}
+
+	public String getJwtSecret() {
+		return jwtSecret;
+	}
+
+	public Long getJwtValidityInSeconds() {
+		return jwtValidityInSeconds;
+	}
+
+	public Long getJwtAdminValidityInSeconds() {
+		return jwtAdminValidityInSeconds;
+	}
+
+	public Long getPotCreationTime() {
+		return potCreationTime;
+	}
+
+	public String getFirstSeedNode() {
+		return firstSeedNode;
+	}
 }

--- a/src/main/java/com/coinblesk/server/config/BeanConfig.java
+++ b/src/main/java/com/coinblesk/server/config/BeanConfig.java
@@ -15,57 +15,57 @@
  */
 package com.coinblesk.server.config;
 
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-
-import com.coinblesk.server.service.ForexService;
-import org.springframework.context.MessageSource;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import com.coinblesk.server.service.ForexService;
 
 @Configuration
 @ComponentScan("com.coinblesk.server")
 @EnableScheduling
 public class BeanConfig {
 
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
-        return new PropertySourcesPlaceholderConfigurer();
-    }
+	@Bean
+	public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+		return new PropertySourcesPlaceholderConfigurer();
+	}
 
-    @Bean
-    public static ForexService.ForexTask forexTask() {
-        return new ForexService.ForexTask();
-    }
+	@Bean
+	public static ForexService.ForexTask forexTask() {
+		return new ForexService.ForexTask();
+	}
 
-    @Bean
-    public static TaskScheduler taskScheduler() {
-        return new ThreadPoolTaskScheduler();
-    }
+	@Bean
+	public static TaskScheduler taskScheduler() {
+		return new ThreadPoolTaskScheduler();
+	}
 
-    @Bean
-    public static PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-    
-    @Bean
-    public MessageSource messageSource() {
-        ResourceBundleMessageSource result = new ResourceBundleMessageSource();
-        result.setBasename("messages");
-        result.setFallbackToSystemLocale(false);
-        return result;
-    }
-    
-    @Bean
-    public LocaleResolver localeResolver() {
-        return new AcceptHeaderLocaleResolver();
-    }
+	@Bean
+	public static PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public MessageSource messageSource() {
+		ResourceBundleMessageSource result = new ResourceBundleMessageSource();
+		result.setBasename("messages");
+		result.setFallbackToSystemLocale(false);
+		return result;
+	}
+
+	@Bean
+	public LocaleResolver localeResolver() {
+		return new AcceptHeaderLocaleResolver();
+	}
 }

--- a/src/main/java/com/coinblesk/server/config/SecurityConfig.java
+++ b/src/main/java/com/coinblesk/server/config/SecurityConfig.java
@@ -15,11 +15,6 @@
  */
 package com.coinblesk.server.config;
 
-import com.coinblesk.server.auth.Http401UnauthorizedEntryPoint;
-import com.coinblesk.server.auth.JWTConfigurer;
-
-
-import com.coinblesk.server.auth.TokenProvider;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -30,6 +25,10 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.coinblesk.server.auth.Http401UnauthorizedEntryPoint;
+import com.coinblesk.server.auth.JWTConfigurer;
+import com.coinblesk.server.auth.TokenProvider;
+
 /**
  *
  * @author Thomas Bocek
@@ -39,69 +38,55 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-    @Autowired
-    private Http401UnauthorizedEntryPoint http401UnauthorizedEntryPoint;
+	@Autowired
+	private Http401UnauthorizedEntryPoint http401UnauthorizedEntryPoint;
 
-    @Autowired
-    private TokenProvider tokenProvider;
+	@Autowired
+	private TokenProvider tokenProvider;
 
-    @Autowired
-    private UserDetailsService userDetailsService;
+	@Autowired
+	private UserDetailsService userDetailsService;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+	@Autowired
+	private PasswordEncoder passwordEncoder;
 
-    final private static String[] REQUIRE_USER_ROLE = {
-        "/user/a/**",
-        "/user/auth/**",
-        "/u/auth/**",
-        "/u/a/**",
-        "/v?/user/a/**",
-        "/v?/user/auth/**",
-        "/v?/u/auth/**",
-        "/v?/u/a/**" };
-    final private static String[] REQUIRE_ADMIN_ROLE = {
-        "/admin/**",
-        "/a/**",
-        "/v?/admin/**",
-        "/v?/a/**"};
+	final private static String[] REQUIRE_USER_ROLE = { "/user/auth/**", "/v?/user/auth/**"};
+	final private static String[] REQUIRE_ADMIN_ROLE = { "/admin/**", "/v?/admin/**" };
 
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) {
-        try {
-            auth
-                .userDetailsService(userDetailsService)
-                    .passwordEncoder(passwordEncoder);
-        } catch (Exception e) {
-            throw new BeanInitializationException("Security configuration failed", e);
-        }
-    }
+	@Autowired
+	public void configureGlobal(AuthenticationManagerBuilder auth) {
+		try {
+			auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder);
+		} catch (Exception e) {
+			throw new BeanInitializationException("Security configuration failed", e);
+		}
+	}
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http
-            .exceptionHandling()
-            .authenticationEntryPoint(http401UnauthorizedEntryPoint)
-        .and()
-            .csrf()
-            .disable()
-            .headers()
-            .frameOptions()
-            .sameOrigin()   // To allow h2 console
-        .and()
-            .sessionManagement()
-            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
-            .authorizeRequests()
-            //.antMatchers("/").permitAll()
-            .antMatchers(REQUIRE_USER_ROLE).hasAuthority(UserRole.USER.getAuthority())
-            .antMatchers(REQUIRE_ADMIN_ROLE).hasAuthority(UserRole.ADMIN.getAuthority())
-        .and()
-            .apply(securityConfigurerAdapter());
-    }
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			.exceptionHandling()
+			.authenticationEntryPoint(http401UnauthorizedEntryPoint)
+		.and()
+			.csrf()
+			.disable()
+			.headers()
+			.frameOptions()
+			.sameOrigin() // To allow h2 console
+		.and()
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+		.and()
+			.authorizeRequests()
+			// .antMatchers("/").permitAll()
+			.antMatchers(REQUIRE_USER_ROLE).hasAuthority(UserRole.USER.getAuthority())
+			.antMatchers(REQUIRE_ADMIN_ROLE).hasAuthority(UserRole.ADMIN.getAuthority())
+		.and()
+			.apply(securityConfigurerAdapter());
+	}
 
-    private JWTConfigurer securityConfigurerAdapter() {
-        return new JWTConfigurer(tokenProvider);
-    }
+	private JWTConfigurer securityConfigurerAdapter() {
+		return new JWTConfigurer(tokenProvider);
+	}
 
 }

--- a/src/main/java/com/coinblesk/server/config/SwaggerConfig.java
+++ b/src/main/java/com/coinblesk/server/config/SwaggerConfig.java
@@ -27,21 +27,20 @@ public class SwaggerConfig {
 				.apiInfo(apiInfo())
 				.select()
 				.apis(any())
-				.paths(regex("^/v[12]/.*$"))
+				.paths(regex("^.*$"))
 				.build()
 				.securitySchemes(apiKeys());
 	}
 
 	@Bean
-	// filters out everything with a single character between slashes /./ or at the end /.$
-	// for adaption see: https://regex101.com/r/goXnVF/1
-	public Docket noShortFormsApi() {
+	// shows everything except /v1
+	public Docket nonV1Api() {
 		return new Docket(SWAGGER_2)
-				.groupName("no-short-forms-api")
+				.groupName("non-v1-api")
 				.apiInfo(apiInfo())
 				.select()
 				.apis(any())
-				.paths(regex("^\\/v[12]((?!\\/.(\\/|$)).)+$"))
+				.paths(regex("^(?!\\/v1).*$"))
 				.build()
 				.securitySchemes(apiKeys());
 	}

--- a/src/main/java/com/coinblesk/server/config/WebMvcConfiguration.java
+++ b/src/main/java/com/coinblesk/server/config/WebMvcConfiguration.java
@@ -37,46 +37,46 @@ import com.coinblesk.util.SerializeUtils;
 @EnableWebMvc
 public class WebMvcConfiguration extends WebMvcConfigurerAdapter {
 
-    @Bean
-    public RequestMappingHandlerMapping requestMappingHandlerMapping() {
-        return new ApiVersionRequestMappingHandlerMapping();
-    }
+	@Bean
+	public RequestMappingHandlerMapping requestMappingHandlerMapping() {
+		return new ApiVersionRequestMappingHandlerMapping();
+	}
 
-    @Override
-    public void configureMessageConverters(List<HttpMessageConverter< ?>> converters) {
-        GsonHttpMessageConverter gsonHttpMessageConverter = new GsonHttpMessageConverter();
-        gsonHttpMessageConverter.setGson(SerializeUtils.GSON);
-        converters.add(gsonHttpMessageConverter);
-    }
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		GsonHttpMessageConverter gsonHttpMessageConverter = new GsonHttpMessageConverter();
+		gsonHttpMessageConverter.setGson(SerializeUtils.GSON);
+		converters.add(gsonHttpMessageConverter);
+	}
 
-    @Override
-    public void addViewControllers(ViewControllerRegistry registry) {
-    	registry.addViewController("/login").setViewName("login");
-        registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
-    }
+	@Override
+	public void addViewControllers(ViewControllerRegistry registry) {
+		registry.addViewController("/login").setViewName("login");
+		registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
+	}
 
-    @Override
-    public void configureViewResolvers(ViewResolverRegistry registry) {
-        InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
-        //no need for JSP
-        //viewResolver.setViewClass(JstlView.class);
-        //viewResolver.setPrefix("/WEB-INF/views/");
-        //viewResolver.setSuffix(".jsp");
-        viewResolver.setPrefix("/static/");
-        viewResolver.setSuffix(".html");
+	@Override
+	public void configureViewResolvers(ViewResolverRegistry registry) {
+		InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
+		// no need for JSP
+		// viewResolver.setViewClass(JstlView.class);
+		// viewResolver.setPrefix("/WEB-INF/views/");
+		// viewResolver.setSuffix(".jsp");
+		viewResolver.setPrefix("/static/");
+		viewResolver.setSuffix(".html");
 
-        registry.viewResolver(viewResolver);
-}
+		registry.viewResolver(viewResolver);
+	}
 
-    /**
-     * Configure ResourceHandlers to serve static resources like CSS/ Javascript etc...
-     */
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/static/**").addResourceLocations("/static/");
+	/**
+	 * Configure ResourceHandlers to serve static resources like CSS/ Javascript etc...
+	 */
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry.addResourceHandler("/static/**").addResourceLocations("/static/");
 
-        // swagger configuration:
-        registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
-        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
-    }
+		// swagger configuration:
+		registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
+		registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+	}
 }

--- a/src/main/java/com/coinblesk/server/controller/AdminController.java
+++ b/src/main/java/com/coinblesk/server/controller/AdminController.java
@@ -15,6 +15,8 @@
  */
 package com.coinblesk.server.controller;
 
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -29,11 +31,11 @@ import javax.servlet.ServletContext;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.TransactionOutput;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -48,85 +50,85 @@ import com.coinblesk.util.Pair;
  */
 
 @Controller
-@RequestMapping(value = {"/admin", "/a"})
-@ApiVersion({"v1", ""})
+@RequestMapping(value = "/admin")
+@ApiVersion({ "v1", "" })
 public class AdminController {
 
-    private static org.slf4j.Logger LOG = LoggerFactory.getLogger(AdminController.class);
+	private static Logger LOG = LoggerFactory.getLogger(AdminController.class);
 
-    @Autowired
-    ServletContext context;
-    
-    @Autowired
-    private WalletService walletService;
+	@Autowired
+	ServletContext context;
 
-    @RequestMapping(method=RequestMethod.GET)
-    public ModelAndView overview() {
-    	Map<String, Object> model = new HashMap<>();
-    	model.put("info", info());
-    	ModelAndView mw = new ModelAndView("admin/overview", model);
-    	return mw;
-    }
-    
-    @RequestMapping(value = {"users"}, method=RequestMethod.GET)
-    public ModelAndView users() {
-    	ModelAndView mw = new ModelAndView("admin/users");
-    	return mw;
-    }
-    
-    @RequestMapping(value = {"tasks"}, method=RequestMethod.GET)
-    public ModelAndView tasks() {
-    	ModelAndView mw = new ModelAndView("admin/tasks");
-    	return mw;
-    }
-    
-    @RequestMapping(value = {"/balance", "/b"}, method=RequestMethod.GET)
-    @ResponseBody
-    public Coin balance() {
-    	return walletService.getBalance();
-    }
-    
-    @RequestMapping(value = {"/addresses", "/a"}, method=RequestMethod.GET)
-    @ResponseBody
-    public Map<Address, Coin> addresses() {
-    	Map<Address, Coin> addressBalances = walletService.getBalanceByAddresses();
-    	LOG.debug("Total addresses: " + addressBalances.size());
-    	return addressBalances;
-    }
-    
-    @RequestMapping(value = {"/utxo", "/u"}, method=RequestMethod.GET)
-    @ResponseBody
-    public List<Pair<String, String>> utxo() {
-    	// cannot return utxo due to GSON recursion
-    	List<TransactionOutput> utxo = walletService.getUnspentOutputs();
-    	List<Pair<String, String>> txOuts = new ArrayList<>();
-    	for (TransactionOutput txOut : utxo) {
-    		txOuts.add(new Pair<>(txOut.getOutPointFor().toString(), txOut.toString()));
-    	}
-    	return txOuts;
-    }
-    
-    @RequestMapping(value = {"/info", "/i"}, method = RequestMethod.GET)
-    @ResponseBody
-    public String info() {
-        LOG.debug("Info called");
-        try {
+	@Autowired
+	private WalletService walletService;
+
+	@RequestMapping(method = GET)
+	public ModelAndView overview() {
+		Map<String, Object> model = new HashMap<>();
+		model.put("info", info());
+		ModelAndView mw = new ModelAndView("admin/overview", model);
+		return mw;
+	}
+
+	@RequestMapping(value = "users", method = GET)
+	public ModelAndView users() {
+		ModelAndView mw = new ModelAndView("admin/users");
+		return mw;
+	}
+
+	@RequestMapping(value = "tasks", method = GET)
+	public ModelAndView tasks() {
+		ModelAndView mw = new ModelAndView("admin/tasks");
+		return mw;
+	}
+
+	@RequestMapping(value = "/balance", method = GET)
+	@ResponseBody
+	public Coin balance() {
+		return walletService.getBalance();
+	}
+
+	@RequestMapping(value = "/addresses", method = GET)
+	@ResponseBody
+	public Map<Address, Coin> addresses() {
+		Map<Address, Coin> addressBalances = walletService.getBalanceByAddresses();
+		LOG.debug("Total addresses: " + addressBalances.size());
+		return addressBalances;
+	}
+
+	@RequestMapping(value = "/utxo", method = GET)
+	@ResponseBody
+	public List<Pair<String, String>> utxo() {
+		// cannot return utxo due to GSON recursion
+		List<TransactionOutput> utxo = walletService.getUnspentOutputs();
+		List<Pair<String, String>> txOuts = new ArrayList<>();
+		for (TransactionOutput txOut : utxo) {
+			txOuts.add(new Pair<>(txOut.getOutPointFor().toString(), txOut.toString()));
+		}
+		return txOuts;
+	}
+
+	@RequestMapping(value = "/info", method = GET)
+	@ResponseBody
+	public String info() {
+		LOG.debug("Info called");
+		try {
 			InputStream inputStream = context.getResourceAsStream("/META-INF/MANIFEST.MF");
 			if (inputStream == null) {
 				throw new IOException("Manifest resource not found.");
 			}
-            Properties prop = new Properties();
-            prop.load(inputStream);
-            List<String> keys = new ArrayList<>(prop.stringPropertyNames());
-            Collections.sort(keys);
-            StringBuilder sb = new StringBuilder();
-            for (String key : keys) {
-                sb.append(key).append(":[");
-                sb.append(prop.get(key)).append("]  ");
-            }
-            return sb.toString().trim();
-        } catch (IOException ex) {
-            return "no manifest found";
-        }
-    }
+			Properties prop = new Properties();
+			prop.load(inputStream);
+			List<String> keys = new ArrayList<>(prop.stringPropertyNames());
+			Collections.sort(keys);
+			StringBuilder sb = new StringBuilder();
+			for (String key : keys) {
+				sb.append(key).append(":[");
+				sb.append(prop.get(key)).append("]  ");
+			}
+			return sb.toString().trim();
+		} catch (IOException ex) {
+			return "no manifest found";
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/controller/ForexController.java
+++ b/src/main/java/com/coinblesk/server/controller/ForexController.java
@@ -15,80 +15,81 @@
  */
 package com.coinblesk.server.controller;
 
+import static com.coinblesk.json.v1.Type.SERVER_ERROR;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 import java.math.BigDecimal;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coinblesk.json.v1.ExchangeRateTO;
 import com.coinblesk.server.service.ForexService;
 import com.coinblesk.server.utils.ApiVersion;
-import com.coinblesk.json.v1.ExchangeRateTO;
-import com.coinblesk.json.v1.Type;
-import java.util.regex.Pattern;
 
 /**
- * Controller for client http requests regarding Transactions between two UserAccounts.
+ * Controller for client http requests regarding Transactions between two
+ * UserAccounts.
  *
  */
 @RestController
-// -> /wallet and /w is for v1 only and should not be used anymore
-@RequestMapping({"/wallet", "/w", "/forex", "/x"})
-@ApiVersion({"v1", ""})
+// "/wallet" is for v1 only and should not be used anymore
+@RequestMapping({ "/wallet", "/forex" })
+@ApiVersion({ "v1", "" })
 public class ForexController {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ForexController.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ForexController.class);
 
-    @Autowired
-    private ForexService forexExchangeRateService;
-    
-    @RequestMapping(value = {"/exchangeRate/{symbol}", "/x/{symbol}"},
-            method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public ResponseEntity<ExchangeRateTO> forexExchangeRate(@PathVariable(value = "symbol") String symbol) {
-        return forexExchangeRate(symbol, "USD");
-    }
-            
+	@Autowired
+	private ForexService forexExchangeRateService;
 
-    /**
-     * Returns up to date exchangerate BTC/CHF
-     *
-     * @return CustomResponseObject with exchangeRate BTC/CHF as a String
-     */
-    @RequestMapping(
-    		value = {"/rate/{from}-{to}", "/r/{from}-{to}"},
-            method = RequestMethod.GET, 
-            produces = "application/json; charset=UTF-8")
-    @ApiVersion({"v2"})
-    @ResponseBody
-    public ResponseEntity<ExchangeRateTO> forexExchangeRate(
-					    		@PathVariable(value = "from") String from,
-					            @PathVariable(value = "to") String to) {
-        LOG.debug("{exchange-rate} - Received exchange rate request for currency {}/{}", from, to);
-        ExchangeRateTO output = new ExchangeRateTO();
-        try {
-            if (!Pattern.matches("[A-Z]{3}", from) || !Pattern.matches("[A-Z]{3}", to)) {
-                output.type(Type.SERVER_ERROR).message("unknown currency symbol");
-                return new ResponseEntity<>(output, HttpStatus.BAD_REQUEST);
-            }
-            BigDecimal exchangeRate = forexExchangeRateService.getExchangeRate(from, to);
-            output.name(from + to);
-            output.rate(exchangeRate.toString());
-            output.setSuccess();
-            LOG.debug("{exchange-rate} - {}, rate: {}", output.name(), output.rate());
-            return new ResponseEntity<>(output, HttpStatus.OK);
-        } catch (Exception e) {
-        	LOG.error("{exchange-rate} - SERVER_ERROR - exception: ", e);
-            output.type(Type.SERVER_ERROR);
-            output.message(e.getMessage());
-            return new ResponseEntity<>(output, HttpStatus.BAD_REQUEST);
-        }
-    }
+	@RequestMapping(value = "/exchangeRate/{symbol}", method = GET, produces = APPLICATION_JSON_UTF8_VALUE)
+	@ResponseBody
+	public ResponseEntity<ExchangeRateTO> forexExchangeRate(@PathVariable(value = "symbol") String symbol) {
+		return forexExchangeRate(symbol, "USD");
+	}
+
+	/**
+	 * Returns up to date exchangerate BTC/CHF
+	 *
+	 * @return CustomResponseObject with exchangeRate BTC/CHF as a String
+	 */
+	@RequestMapping(value = "/rate/{from}-{to}", method = GET, produces = APPLICATION_JSON_UTF8_VALUE)
+	@ApiVersion({ "v2" })
+	@ResponseBody
+	public ResponseEntity<ExchangeRateTO> forexExchangeRate(@PathVariable(value = "from") String from,
+			@PathVariable(value = "to") String to) {
+
+		LOG.debug("{exchange-rate} - Received exchange rate request for currency {}/{}", from, to);
+		ExchangeRateTO output = new ExchangeRateTO();
+		try {
+			if (!Pattern.matches("[A-Z]{3}", from) || !Pattern.matches("[A-Z]{3}", to)) {
+				output.type(SERVER_ERROR).message("unknown currency symbol");
+				return new ResponseEntity<>(output, BAD_REQUEST);
+			}
+			BigDecimal exchangeRate = forexExchangeRateService.getExchangeRate(from, to);
+			output.name(from + to);
+			output.rate(exchangeRate.toString());
+			output.setSuccess();
+
+			LOG.debug("{exchange-rate} - {}, rate: {}", output.name(), output.rate());
+			return new ResponseEntity<>(output, OK);
+
+		} catch (Exception e) {
+			LOG.error("{exchange-rate} - SERVER_ERROR - exception: ", e);
+			output.type(SERVER_ERROR);
+			output.message(e.getMessage());
+			return new ResponseEntity<>(output, BAD_REQUEST);
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/controller/ForexController.java
+++ b/src/main/java/com/coinblesk/server/controller/ForexController.java
@@ -64,7 +64,10 @@ public class ForexController {
 	 *
 	 * @return CustomResponseObject with exchangeRate BTC/CHF as a String
 	 */
-	@RequestMapping(value = "/rate/{from}-{to}", method = GET, produces = APPLICATION_JSON_UTF8_VALUE)
+	@RequestMapping(
+			value = "/rate/{from}-{to}",
+			method = GET,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ApiVersion({ "v2" })
 	@ResponseBody
 	public ResponseEntity<ExchangeRateTO> forexExchangeRate(@PathVariable(value = "from") String from,

--- a/src/main/java/com/coinblesk/server/controller/PaymentController.java
+++ b/src/main/java/com/coinblesk/server/controller/PaymentController.java
@@ -41,10 +41,8 @@ import org.bitcoinj.script.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -136,8 +134,9 @@ public class PaymentController {
 			// Input is OK: create and return address
 			final TimeLockedAddress address = new TimeLockedAddress(clientKey.getPubKey(), serverKey.getPubKey(),
 					lockTime);
-			TimeLockedAddressTO responseTO = new TimeLockedAddressTO()	.currentDate(startTime.toEpochMilli())
-																		.timeLockedAddress(address);
+			TimeLockedAddressTO responseTO = new TimeLockedAddressTO()
+					.currentDate(startTime.toEpochMilli())
+					.timeLockedAddress(address);
 
 			// save if not exists
 			if (!keyService.addressExists(address.getAddressHash())) {
@@ -277,9 +276,10 @@ public class PaymentController {
 			return responseTO;
 		} catch (Exception e) {
 			LOG.error("{} - clientPubKey={} - SERVER_ERROR: ", tag, clientPubKeyHex, e);
-			return new SignVerifyTO()	.currentDate(System.currentTimeMillis())
-										.type(Type.SERVER_ERROR)
-										.message(e.getMessage());
+			return new SignVerifyTO()
+					.currentDate(System.currentTimeMillis())
+					.type(Type.SERVER_ERROR)
+					.message(e.getMessage());
 		} finally {
 			LOG.debug("{} - clientPubKey={} - finished in {} ms", tag, clientPubKeyHex,
 					Duration.between(startTime, Instant.now()).toMillis());

--- a/src/main/java/com/coinblesk/server/controller/PaymentController.java
+++ b/src/main/java/com/coinblesk/server/controller/PaymentController.java
@@ -74,161 +74,156 @@ import com.coinblesk.util.SerializeUtils;
  *
  */
 @RestController
-@RequestMapping(value = {"/payment", "/p"})
-@ApiVersion({"v1", ""})
+@RequestMapping(value = { "/payment", "/p" })
+@ApiVersion({ "v1", "" })
 public class PaymentController {
 
-    private final static Logger LOG = LoggerFactory.getLogger(PaymentController.class);
-    private final static Set<String> CONCURRENCY = Collections.synchronizedSet(new HashSet<>());
+	private final static Logger LOG = LoggerFactory.getLogger(PaymentController.class);
+	private final static Set<String> CONCURRENCY = Collections.synchronizedSet(new HashSet<>());
 
-    @Autowired
-    private AppConfig appConfig;
+	@Autowired
+	private AppConfig appConfig;
 
-    @Autowired
-    private WalletService walletService;
+	@Autowired
+	private WalletService walletService;
 
-    @Autowired
-    private KeyService keyService;
+	@Autowired
+	private KeyService keyService;
 
-    @Autowired
-    private TransactionService txService;
-    
-    
-    @RequestMapping(
-    		value = {"/createTimeLockedAddress", "/ctla"},
-    		method = RequestMethod.POST,
-    		consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public TimeLockedAddressTO createTimeLockedAddress(@RequestBody TimeLockedAddressTO input) {
-    	final String tag = "{createTimeLockedAddress}";
-    	final Instant startTime = Instant.now();
-    	final NetworkParameters params = appConfig.getNetworkParameters();
-    	
-    	try {
-    		final TimeLockedAddressTO error = ToUtils.checkInput(input);
-            if (error != null) {
-            	LOG.debug("{} - input error - type={}", tag, error.type().toString());
-                return error;
-            }
+	@Autowired
+	private TransactionService txService;
 
-            // set client/server keys
-    		final ECKey clientKey = ECKey.fromPublicOnly(input.publicKey());
-    		final String clientPubKeyHex = clientKey.getPublicKeyAsHex();
-    		final Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+	@RequestMapping(value = { "/createTimeLockedAddress",
+			"/ctla" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public TimeLockedAddressTO createTimeLockedAddress(@RequestBody TimeLockedAddressTO input) {
+		final String tag = "{createTimeLockedAddress}";
+		final Instant startTime = Instant.now();
+		final NetworkParameters params = appConfig.getNetworkParameters();
+
+		try {
+			final TimeLockedAddressTO error = ToUtils.checkInput(input);
+			if (error != null) {
+				LOG.debug("{} - input error - type={}", tag, error.type().toString());
+				return error;
+			}
+
+			// set client/server keys
+			final ECKey clientKey = ECKey.fromPublicOnly(input.publicKey());
+			final String clientPubKeyHex = clientKey.getPublicKeyAsHex();
+			final Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
 			if (keys == null) {
 				LOG.debug("{} - keys not found for clientPubKey={}", tag, clientPubKeyHex);
 				return new TimeLockedAddressTO().type(Type.KEYS_NOT_FOUND);
 			}
-			final ECKey serverKey = ECKey.fromPrivateAndPrecalculatedPublic(
-					keys.serverPrivateKey(), keys.serverPublicKey());
-    		
-    		// lockTime: do not allow locking by block and lockTime in the past
-            final long lockTime = input.lockTime();
-            if (!BitcoinUtils.isLockTimeByTime(lockTime) || 
-            	 BitcoinUtils.isAfterLockTime(startTime.getEpochSecond(), lockTime)) {
-            	return new TimeLockedAddressTO().type(Type.LOCKTIME_ERROR);
-            }
-            
-            // Input is OK: create and return address
-            final TimeLockedAddress address = new TimeLockedAddress(
-            		clientKey.getPubKey(), serverKey.getPubKey(), lockTime);
-            TimeLockedAddressTO responseTO = new TimeLockedAddressTO()
-            		.currentDate(startTime.toEpochMilli())
-            		.timeLockedAddress(address);
-            
-            // save if not exists
-            if (!keyService.addressExists(address.getAddressHash())) {
-                keyService.storeTimeLockedAddress(keys, address);
-                walletService.addWatching(address.createPubkeyScript());
-                //TODO: better below?
-                //walletService.addWatching(address.getAddress(params));
-                responseTO.setSuccess();
-                LOG.debug("{} - new address created: {}", tag, address.toStringDetailed(params));
-            } else {
-            	responseTO.type(Type.SUCCESS_BUT_ADDRESS_ALREADY_EXISTS);
-                LOG.debug("{} - address already exists (multiple requests in a short time?): {}", 
-                		tag, address.toStringDetailed(params));
-            }
-            
-            SerializeUtils.signJSON(responseTO, serverKey);
-            LOG.info("{} - created address: {}, clientPubKey={}", tag, address.toString(params), clientPubKeyHex);
-    		return responseTO;
-    		
-    	} catch (Exception e) {
-    		LOG.error("{} - Failed with exception: ", tag, e);
-    		return new TimeLockedAddressTO()
-    				.type(Type.SERVER_ERROR)
-    				.message(e.getMessage());
-    	} finally {
-    		LOG.debug("{} - finished in {} ms", tag, Duration.between(startTime, Instant.now()).toMillis());
-    	}
-    }
-    
-    @RequestMapping(value = {"/signverify", "/sv"}, 
-			method = RequestMethod.POST,
-	        consumes = "application/json; charset=UTF-8",
-	        produces = "application/json; charset=UTF-8")
+			final ECKey serverKey = ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(),
+					keys.serverPublicKey());
+
+			// lockTime: do not allow locking by block and lockTime in the past
+			final long lockTime = input.lockTime();
+			if (!BitcoinUtils.isLockTimeByTime(lockTime)
+					|| BitcoinUtils.isAfterLockTime(startTime.getEpochSecond(), lockTime)) {
+				return new TimeLockedAddressTO().type(Type.LOCKTIME_ERROR);
+			}
+
+			// Input is OK: create and return address
+			final TimeLockedAddress address = new TimeLockedAddress(clientKey.getPubKey(), serverKey.getPubKey(),
+					lockTime);
+			TimeLockedAddressTO responseTO = new TimeLockedAddressTO()	.currentDate(startTime.toEpochMilli())
+																		.timeLockedAddress(address);
+
+			// save if not exists
+			if (!keyService.addressExists(address.getAddressHash())) {
+				keyService.storeTimeLockedAddress(keys, address);
+				walletService.addWatching(address.createPubkeyScript());
+				// TODO: better below?
+				// walletService.addWatching(address.getAddress(params));
+				responseTO.setSuccess();
+				LOG.debug("{} - new address created: {}", tag, address.toStringDetailed(params));
+			} else {
+				responseTO.type(Type.SUCCESS_BUT_ADDRESS_ALREADY_EXISTS);
+				LOG.debug("{} - address already exists (multiple requests in a short time?): {}", tag,
+						address.toStringDetailed(params));
+			}
+
+			SerializeUtils.signJSON(responseTO, serverKey);
+			LOG.info("{} - created address: {}, clientPubKey={}", tag, address.toString(params), clientPubKeyHex);
+			return responseTO;
+
+		} catch (Exception e) {
+			LOG.error("{} - Failed with exception: ", tag, e);
+			return new TimeLockedAddressTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		} finally {
+			LOG.debug("{} - finished in {} ms", tag, Duration.between(startTime, Instant.now()).toMillis());
+		}
+	}
+
+	@RequestMapping(value = { "/signverify",
+			"/sv" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
 	@ResponseBody
 	public SignVerifyTO signVerify(@RequestBody SignVerifyTO request) {
-    	final String tag = "{signverify}";
-    	final Instant startTime = Instant.now();
-    	String clientPubKeyHex = "(UNKNOWN)";
-    	
+		final String tag = "{signverify}";
+		final Instant startTime = Instant.now();
+		String clientPubKeyHex = "(UNKNOWN)";
+
 		try {
 			final NetworkParameters params = appConfig.getNetworkParameters();
 			final Keys keys;
 			final ECKey clientKey = ECKey.fromPublicOnly(request.publicKey());
-    		clientPubKeyHex = clientKey.getPublicKeyAsHex();
-    		final ECKey serverKey;
-    		final Transaction transaction;
-    		final List<TransactionSignature> clientSigs;
-    		
-    		// clear payeeSig since client sig does not cover it
-    		final TxSig payeeSigInput = request.payeeMessageSig();
-    		request.payeeMessageSig(null);
-    		final byte[] payeePubKey = request.payeePublicKey();
-    		request.payeePublicKey(null);
-    		
-                //NFC has a hard limit of 245, thus we have no space for the date yet.
-    		final SignVerifyTO error = ToUtils.checkInput(request, false);
+			clientPubKeyHex = clientKey.getPublicKeyAsHex();
+			final ECKey serverKey;
+			final Transaction transaction;
+			final List<TransactionSignature> clientSigs;
+
+			// clear payeeSig since client sig does not cover it
+			final TxSig payeeSigInput = request.payeeMessageSig();
+			request.payeeMessageSig(null);
+			final byte[] payeePubKey = request.payeePublicKey();
+			request.payeePublicKey(null);
+
+			// NFC has a hard limit of 245, thus we have no space for the date
+			// yet.
+			final SignVerifyTO error = ToUtils.checkInput(request, false);
 			if (error != null) {
 				LOG.info("{} - clientPubKey={} - input error - type={}", tag, clientPubKeyHex, error.type());
 				return error;
 			}
-				
+
 			LOG.debug("{} - clientPubKey={} - request", tag, clientPubKeyHex);
-	        keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-	        if (keys == null || keys.clientPublicKey() == null ||
-	        		keys.serverPrivateKey() == null || keys.serverPublicKey() == null) {
-	        	LOG.debug("{} - clientPubKey={} - KEYS_NOT_FOUND", tag, clientPubKeyHex);
-	        	return ToUtils.newInstance(SignVerifyTO.class, Type.KEYS_NOT_FOUND);
-	        }
-	        serverKey = ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(), keys.serverPublicKey());
-	        
+			keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+			if (keys == null
+					|| keys.clientPublicKey() == null
+					|| keys.serverPrivateKey() == null
+					|| keys.serverPublicKey() == null) {
+				LOG.debug("{} - clientPubKey={} - KEYS_NOT_FOUND", tag, clientPubKeyHex);
+				return ToUtils.newInstance(SignVerifyTO.class, Type.KEYS_NOT_FOUND);
+			}
+			serverKey = ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(), keys.serverPublicKey());
+
 			if (keys.timeLockedAddresses().isEmpty()) {
 				LOG.debug("{} - clientPubKey={} - ADDRESS_EMPTY", tag, clientPubKeyHex);
-				return ToUtils.newInstance(SignVerifyTO.class, Type.ADDRESS_EMPTY, serverKey); 
+				return ToUtils.newInstance(SignVerifyTO.class, Type.ADDRESS_EMPTY, serverKey);
 			}
-	     		        
-	        /*
-	         * Got a transaction in the request - sign
-	         */
+
+			/*
+			 * Got a transaction in the request - sign
+			 */
 			if (request.transaction() != null) {
 				transaction = new Transaction(params, request.transaction());
 				LOG.debug("{} - clientPubKey={} - transaction from input: \n{}", tag, clientPubKeyHex, transaction);
-				
+
 				List<TransactionOutput> outputsToAdd = new ArrayList<>();
-				// if amount to spend && address provided, add corresponding output
+				// if amount to spend && address provided, add corresponding
+				// output
 				if (request.amountToSpend() > 0 && request.addressTo() != null && !request.addressTo().isEmpty()) {
-					TransactionOutput txOut = transaction.addOutput(
-							Coin.valueOf(request.amountToSpend()), 
+					TransactionOutput txOut = transaction.addOutput(Coin.valueOf(request.amountToSpend()),
 							Address.fromBase58(params, request.addressTo()));
 					outputsToAdd.add(txOut);
 					LOG.debug("{} - added output={} to Tx={}", tag, txOut, transaction.getHash());
 				}
-				
-				// if change amount is provided, we add an output to the most recently created address of the client.
+
+				// if change amount is provided, we add an output to the most
+				// recently created address of the client.
 				if (request.amountChange() > 0) {
 					Address changeAddress = keys.latestTimeLockedAddresses().toAddress(params);
 					Coin changeAmount = Coin.valueOf(request.amountChange());
@@ -236,7 +231,7 @@ public class PaymentController {
 					outputsToAdd.add(changeOut);
 					LOG.debug("{} - added change output={} to Tx={}", tag, changeOut, transaction.getHash());
 				}
-				
+
 				if (!outputsToAdd.isEmpty()) {
 					outputsToAdd = BitcoinUtils.sortOutputs(outputsToAdd);
 					transaction.clearOutputs();
@@ -244,479 +239,468 @@ public class PaymentController {
 						transaction.addOutput(to);
 					}
 				}
-				
+
 			} else {
 				LOG.debug("{} - clientPubKey={} - INPUT_MISMATCH", tag, clientPubKeyHex);
 				return ToUtils.newInstance(SignVerifyTO.class, Type.INPUT_MISMATCH, serverKey);
 			}
-			
+
 			// check signatures
 			if (request.signatures() == null || (request.signatures().size() != transaction.getInputs().size())) {
-				LOG.debug("{} - clientPubKey={} - INPUT_MISMATCH - number of signatures ({}) != number of inputs ({})", 
-					tag, clientPubKeyHex, request.signatures().size(), transaction.getInputs().size());
+				LOG.debug("{} - clientPubKey={} - INPUT_MISMATCH - number of signatures ({}) != number of inputs ({})",
+						tag, clientPubKeyHex, request.signatures().size(), transaction.getInputs().size());
 				return ToUtils.newInstance(SignVerifyTO.class, Type.INPUT_MISMATCH, serverKey);
 			}
 
 			clientSigs = SerializeUtils.deserializeSignatures(request.signatures());
 			SignVerifyTO responseTO = txService.signVerifyTransaction(transaction, clientKey, serverKey, clientSigs);
 			SerializeUtils.signJSON(responseTO, serverKey);
-			
-			// if we know the receiver, we create an additional signature with the key of the payee.
+
+			// if we know the receiver, we create an additional signature with
+			// the key of the payee.
 			if (maybeAppendPayeeSignature(request, payeePubKey, payeeSigInput, responseTO)) {
 				LOG.debug("{} - created additional signature for payee.", tag);
 			} else {
 				LOG.debug("{} - payee unknown (no additional signature)");
 			}
-			
+
 			return responseTO;
 		} catch (Exception e) {
 			LOG.error("{} - clientPubKey={} - SERVER_ERROR: ", tag, clientPubKeyHex, e);
-	        return new SignVerifyTO()
-	        		.currentDate(System.currentTimeMillis())
-	        		.type(Type.SERVER_ERROR)
-	                .message(e.getMessage());
+			return new SignVerifyTO()	.currentDate(System.currentTimeMillis())
+										.type(Type.SERVER_ERROR)
+										.message(e.getMessage());
 		} finally {
-			LOG.debug("{} - clientPubKey={} - finished in {} ms", 
-					tag, clientPubKeyHex, Duration.between(startTime, Instant.now()).toMillis());
+			LOG.debug("{} - clientPubKey={} - finished in {} ms", tag, clientPubKeyHex,
+					Duration.between(startTime, Instant.now()).toMillis());
 		}
 	}
-    
-    private boolean maybeAppendPayeeSignature(SignVerifyTO request, 
-	    											byte[] payeePubKey, 
-	    											TxSig payeeTxSig, 
-	    											SignVerifyTO response) {
-    	if (payeePubKey == null || !ECKey.isPubKeyCanonical(payeePubKey) || payeeTxSig == null) {
-    		return false;
-    	}
-		
-    	Keys payeeKeys = keyService.getByClientPublicKey(payeePubKey);
-    	if (payeeKeys == null) {
-    		return false; // payee unknown / external user.
-    	}
-    	ECKey payeeClientKey = ECKey.fromPublicOnly(payeePubKey);
-		ECKey payeeServerKey = ECKey.fromPrivateAndPrecalculatedPublic(
-				payeeKeys.serverPrivateKey(), payeeKeys.serverPublicKey());
-		
+
+	private boolean maybeAppendPayeeSignature(SignVerifyTO request, byte[] payeePubKey, TxSig payeeTxSig,
+			SignVerifyTO response) {
+		if (payeePubKey == null || !ECKey.isPubKeyCanonical(payeePubKey) || payeeTxSig == null) {
+			return false;
+		}
+
+		Keys payeeKeys = keyService.getByClientPublicKey(payeePubKey);
+		if (payeeKeys == null) {
+			return false; // payee unknown / external user.
+		}
+		ECKey payeeClientKey = ECKey.fromPublicOnly(payeePubKey);
+		ECKey payeeServerKey = ECKey.fromPrivateAndPrecalculatedPublic(payeeKeys.serverPrivateKey(),
+				payeeKeys.serverPublicKey());
+
 		// check that payee signature is valid
 		request.payeePublicKey(payeePubKey);
 		if (!SerializeUtils.verifyJSONSignatureRaw(request, payeeTxSig, payeeClientKey)) {
 			return false;
 		}
 		request.payeePublicKey(null);
-		
+
 		// all checks OK - sign and append signature
 		response.payeePublicKey(payeeServerKey.getPubKey());
 		TxSig payeeSigOutput = SerializeUtils.signJSONRaw(response, payeeServerKey);
 		response.payeeMessageSig(payeeSigOutput);
 		return true;
-    }
+	}
 
 	/**
-     * Input is the KeyTO with the client public key. The server will create for this client public key its
-     * own server keypair and return the server public key, or indicate an error in KeyTO (or via status
-     * code). Make sure to check for isSuccess(). Internally the server will hash the client public key with
-     * SHA-256 (UUID) and clients need to identify themselfs with this UUID for subsequent calls.
-     *
-     */
-    @RequestMapping(value = {"/key-exchange", "/x"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public KeyTO keyExchange(@RequestBody KeyTO input) {
-        final long startTime = System.currentTimeMillis();
-        final String tag = "{key-exchange}";
-        try {
-            if (input.publicKey() == null || !ECKey.isPubKeyCanonical(input.publicKey())) {
-            	LOG.debug("{} - INPUT_MISMATCH", tag);
-                return ToUtils.newInstance(KeyTO.class, Type.INPUT_MISMATCH);
-            }
-            
-            LOG.debug("{} - clientPubKey={}", tag, SerializeUtils.bytesToHex(input.publicKey()));
-            //no input checking as input may not be signed
-            final byte[] clientPublicKey = input.publicKey();
-            final ECKey serverEcKey = new ECKey();
-            final List<ECKey> keyList = new ArrayList<>(2);
-            keyList.add(ECKey.fromPublicOnly(clientPublicKey));
-            keyList.add(serverEcKey);
-            
-            //2-of-2 multisig
-            final Script script = BitcoinUtils.createP2SHOutputScript(2, keyList);
-            final Pair<Boolean, Keys> retVal = keyService.storeKeysAndAddress(
-            		clientPublicKey,
-                    serverEcKey.getPubKey(),
-                    serverEcKey.getPrivKeyBytes());
+	 * Input is the KeyTO with the client public key. The server will create for
+	 * this client public key its own server keypair and return the server
+	 * public key, or indicate an error in KeyTO (or via status code). Make sure
+	 * to check for isSuccess(). Internally the server will hash the client
+	 * public key with SHA-256 (UUID) and clients need to identify themselfs
+	 * with this UUID for subsequent calls.
+	 *
+	 */
+	@RequestMapping(value = { "/key-exchange",
+			"/x" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public KeyTO keyExchange(@RequestBody KeyTO input) {
+		final long startTime = System.currentTimeMillis();
+		final String tag = "{key-exchange}";
+		try {
+			if (input.publicKey() == null || !ECKey.isPubKeyCanonical(input.publicKey())) {
+				LOG.debug("{} - INPUT_MISMATCH", tag);
+				return ToUtils.newInstance(KeyTO.class, Type.INPUT_MISMATCH);
+			}
 
-            final KeyTO serverKeyTO = new KeyTO().currentDate(System.currentTimeMillis());
-            if (retVal.element0()) {
-                walletService.addWatching(script);
-            	serverKeyTO.publicKey(serverEcKey.getPubKey());
-                serverKeyTO.setSuccess();
-                SerializeUtils.signJSON(serverKeyTO, serverEcKey);
-            } else {
-            	Keys keys = retVal.element1();
-                serverKeyTO.publicKey(keys.serverPublicKey());
-                serverKeyTO.type(Type.SUCCESS_BUT_KEY_ALREADY_EXISTS);
-                ECKey existingServerKey = ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(), keys.serverPublicKey());
-                SerializeUtils.signJSON(serverKeyTO, existingServerKey);
-            }
-            LOG.debug("{} - done - {}", serverKeyTO.type().toString());
-            return serverKeyTO;
-        } catch (Exception e) {
-            LOG.error("{} - SERVER_ERROR: ", e);
-            return new KeyTO()
-            		.currentDate(System.currentTimeMillis())
-                    .type(Type.SERVER_ERROR)
-                    .message(e.getMessage());
-        } finally {
-        	LOG.debug("{} - finished in {} ms", tag, (System.currentTimeMillis()-startTime));
-        }
-    }
+			LOG.debug("{} - clientPubKey={}", tag, SerializeUtils.bytesToHex(input.publicKey()));
+			// no input checking as input may not be signed
+			final byte[] clientPublicKey = input.publicKey();
+			final ECKey serverEcKey = new ECKey();
+			final List<ECKey> keyList = new ArrayList<>(2);
+			keyList.add(ECKey.fromPublicOnly(clientPublicKey));
+			keyList.add(serverEcKey);
 
-    @RequestMapping(value = {"/balance", "/b"}, method = RequestMethod.GET,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public BalanceTO balance(@RequestBody BalanceTO input) {
-        final long start = System.currentTimeMillis();
-        try {
-            if(input.publicKey() == null || input.publicKey().length == 0) {
-                return new BalanceTO().type(Type.KEYS_NOT_FOUND);
-            }
-            LOG.debug("{balance} clientHash for {}", SerializeUtils.bytesToHex(input.publicKey()));
-            final BalanceTO error = ToUtils.checkInput(input);
-            if (error != null) {
-                return error;
-            }
-            final NetworkParameters params = appConfig.getNetworkParameters();
-            final List<ECKey> keys = keyService.getPublicECKeysByClientPublicKey(input.publicKey());
-            final Script script = BitcoinUtils.createP2SHOutputScript(2, keys);
-            final Address p2shAddressFrom = script.getToAddress(params);
-            List<TransactionOutput> outputs = walletService.verifiedOutputs(params, p2shAddressFrom);
-            LOG.debug("{balance} nr. of outputs from network {} for {}. Full list: {}", outputs.size(), "tdb",
-                    outputs);
-            long total = 0;
-            for (TransactionOutput transactionOutput : outputs) {
-                total += transactionOutput.getValue().value;
-            }
-            LOG.debug("{balance}:{} done", (System.currentTimeMillis() - start));
-            return new BalanceTO().balance(total);
+			// 2-of-2 multisig
+			final Script script = BitcoinUtils.createP2SHOutputScript(2, keyList);
+			final Pair<Boolean, Keys> retVal = keyService.storeKeysAndAddress(clientPublicKey, serverEcKey.getPubKey(),
+					serverEcKey.getPrivKeyBytes());
 
-        } catch (Exception e) {
-            LOG.error("{balance} keys error", e);
-            return new BalanceTO()
-                    .type(Type.SERVER_ERROR)
-                    .message(e.getMessage());
-        }
-    }
+			final KeyTO serverKeyTO = new KeyTO().currentDate(System.currentTimeMillis());
+			if (retVal.element0()) {
+				walletService.addWatching(script);
+				serverKeyTO.publicKey(serverEcKey.getPubKey());
+				serverKeyTO.setSuccess();
+				SerializeUtils.signJSON(serverKeyTO, serverEcKey);
+			} else {
+				Keys keys = retVal.element1();
+				serverKeyTO.publicKey(keys.serverPublicKey());
+				serverKeyTO.type(Type.SUCCESS_BUT_KEY_ALREADY_EXISTS);
+				ECKey existingServerKey = ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(),
+						keys.serverPublicKey());
+				SerializeUtils.signJSON(serverKeyTO, existingServerKey);
+			}
+			LOG.debug("{} - done - {}", serverKeyTO.type().toString());
+			return serverKeyTO;
+		} catch (Exception e) {
+			LOG.error("{} - SERVER_ERROR: ", e);
+			return new KeyTO().currentDate(System.currentTimeMillis()).type(Type.SERVER_ERROR).message(e.getMessage());
+		} finally {
+			LOG.debug("{} - finished in {} ms", tag, (System.currentTimeMillis() - startTime));
+		}
+	}
 
-    @RequestMapping(value = {"/refund", "/r"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public RefundTO refund(@RequestBody RefundTO input) {
-        final long start = System.currentTimeMillis();
-        try {
-            if(input.publicKey() == null || input.publicKey().length == 0) {
-                return new RefundTO().type(Type.KEYS_NOT_FOUND);
-            }
-            LOG.debug("{refund} for {}", SerializeUtils.bytesToHex(input.publicKey()));
-            final RefundTO error = ToUtils.checkInput(input);
-            if (error != null) {
-                return error;
-            }
-            final List<ECKey> keys = keyService.getECKeysByClientPublicKey(input.publicKey());
-            if (keys == null || keys.size() != 2) {
-                return new RefundTO().type(Type.KEYS_NOT_FOUND);
-            }
-            final NetworkParameters params = appConfig.getNetworkParameters();
-            final ECKey serverKey = keys.get(1);
-            final ECKey clientKey = keys.get(0);
-            final Script redeemScript = BitcoinUtils.createRedeemScript(2, keys);
-            //this is how the client sees the tx
-            final Transaction refundTransaction;
-            
-            //choice 1 - full refund tx
-            if (input.refundTransaction() != null) {
-                    refundTransaction = new Transaction(params, input.refundTransaction());
-            } 
-            //choice 2 - send outpoints, coins, where to send btc to, and amount
-            else if (input.outpointsCoinPair() != null && !input.outpointsCoinPair().isEmpty()
-                    && input.lockTimeSeconds() > 0 && input.refundSendTo() != null) {
-                final List<Pair<TransactionOutPoint, Coin>> refundClientPoints = SerializeUtils
-                        .deserializeOutPointsCoin(
-                                params, input.outpointsCoinPair());
-                try {
-                    Address refundSendTo = Address.fromBase58(params, input.refundSendTo());
-                    refundTransaction = BitcoinUtils.createRefundTx(params, refundClientPoints, redeemScript,
-                            refundSendTo, input.lockTimeSeconds());
-                } catch (AddressFormatException e) {
-                    LOG.debug("{refund}:{} empty address for", (System.currentTimeMillis() - start));
-                    return new RefundTO().type(Type.ADDRESS_EMPTY).message(e.getMessage());
-                }
-            }
-            //wrong choice
-            else {
-                return new RefundTO().type(Type.INPUT_MISMATCH);
-            }
-            
-            //sanity check
-            refundTransaction.verify();
-            
-            List<TransactionSignature> clientSigs = SerializeUtils.deserializeSignatures(input
-                    .clientSignatures());
+	@RequestMapping(value = { "/balance",
+			"/b" }, method = RequestMethod.GET, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public BalanceTO balance(@RequestBody BalanceTO input) {
+		final long start = System.currentTimeMillis();
+		try {
+			if (input.publicKey() == null || input.publicKey().length == 0) {
+				return new BalanceTO().type(Type.KEYS_NOT_FOUND);
+			}
+			LOG.debug("{balance} clientHash for {}", SerializeUtils.bytesToHex(input.publicKey()));
+			final BalanceTO error = ToUtils.checkInput(input);
+			if (error != null) {
+				return error;
+			}
+			final NetworkParameters params = appConfig.getNetworkParameters();
+			final List<ECKey> keys = keyService.getPublicECKeysByClientPublicKey(input.publicKey());
+			final Script script = BitcoinUtils.createP2SHOutputScript(2, keys);
+			final Address p2shAddressFrom = script.getToAddress(params);
+			List<TransactionOutput> outputs = walletService.verifiedOutputs(params, p2shAddressFrom);
+			LOG.debug("{balance} nr. of outputs from network {} for {}. Full list: {}", outputs.size(), "tdb", outputs);
+			long total = 0;
+			for (TransactionOutput transactionOutput : outputs) {
+				total += transactionOutput.getValue().value;
+			}
+			LOG.debug("{balance}:{} done", (System.currentTimeMillis() - start));
+			return new BalanceTO().balance(total);
 
-            //now we can check the client sigs
-            if (!SerializeUtils.verifyTxSignatures(refundTransaction, clientSigs, redeemScript, clientKey)) {
-                LOG.debug("{refund} signature mismatch for tx {} with sigs {}", refundTransaction, clientSigs);
-                return new RefundTO().type(Type.SIGNATURE_ERROR);
-            } else {
-                LOG.debug("{refund} signature good! for tx {} with sigs", refundTransaction, clientSigs);
-            }
-            //also check the server sigs, that the reedemscript has our public key
-            
+		} catch (Exception e) {
+			LOG.error("{balance} keys error", e);
+			return new BalanceTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
 
-            Collections.sort(keys, ECKey.PUBKEY_COMPARATOR);
+	@RequestMapping(value = { "/refund",
+			"/r" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public RefundTO refund(@RequestBody RefundTO input) {
+		final long start = System.currentTimeMillis();
+		try {
+			if (input.publicKey() == null || input.publicKey().length == 0) {
+				return new RefundTO().type(Type.KEYS_NOT_FOUND);
+			}
+			LOG.debug("{refund} for {}", SerializeUtils.bytesToHex(input.publicKey()));
+			final RefundTO error = ToUtils.checkInput(input);
+			if (error != null) {
+				return error;
+			}
+			final List<ECKey> keys = keyService.getECKeysByClientPublicKey(input.publicKey());
+			if (keys == null || keys.size() != 2) {
+				return new RefundTO().type(Type.KEYS_NOT_FOUND);
+			}
+			final NetworkParameters params = appConfig.getNetworkParameters();
+			final ECKey serverKey = keys.get(1);
+			final ECKey clientKey = keys.get(0);
+			final Script redeemScript = BitcoinUtils.createRedeemScript(2, keys);
+			// this is how the client sees the tx
+			final Transaction refundTransaction;
 
-            List<TransactionSignature> serverSigs = BitcoinUtils
-                    .partiallySign(refundTransaction, redeemScript, serverKey);
-            boolean clientFirst = BitcoinUtils.clientFirst(keys, clientKey);
-            BitcoinUtils.applySignatures(refundTransaction, redeemScript, clientSigs, serverSigs, clientFirst);
-            input.serverSignatures(SerializeUtils.serializeSignatures(serverSigs));
-            //TODO: enable
-            //refundTransaction.verify(); make sure those inputs are from the known p2sh address (min conf)
-            byte[] refundTx = refundTransaction.unsafeBitcoinSerialize();
-            txService.addTransaction(input.publicKey(), refundTx, refundTransaction.getHash().getBytes(), false);
-            LOG.debug("{refund}:{} done", (System.currentTimeMillis() - start));
-            return new RefundTO()
-                    .setSuccess()
-                    .refundTransaction(refundTx)
-                    .serverSignatures(SerializeUtils.serializeSignatures(serverSigs));
-        } catch (Exception e) {
-            LOG.error("register keys error", e);
-            return new RefundTO()
-                    .type(Type.SERVER_ERROR)
-                    .message(e.getMessage());
-        }
-    }
+			// choice 1 - full refund tx
+			if (input.refundTransaction() != null) {
+				refundTransaction = new Transaction(params, input.refundTransaction());
+			}
+			// choice 2 - send outpoints, coins, where to send btc to, and
+			// amount
+			else if (input.outpointsCoinPair() != null
+					&& !input.outpointsCoinPair().isEmpty()
+					&& input.lockTimeSeconds() > 0
+					&& input.refundSendTo() != null) {
+				final List<Pair<TransactionOutPoint, Coin>> refundClientPoints = SerializeUtils.deserializeOutPointsCoin(
+						params, input.outpointsCoinPair());
+				try {
+					Address refundSendTo = Address.fromBase58(params, input.refundSendTo());
+					refundTransaction = BitcoinUtils.createRefundTx(params, refundClientPoints, redeemScript,
+							refundSendTo, input.lockTimeSeconds());
+				} catch (AddressFormatException e) {
+					LOG.debug("{refund}:{} empty address for", (System.currentTimeMillis() - start));
+					return new RefundTO().type(Type.ADDRESS_EMPTY).message(e.getMessage());
+				}
+			}
+			// wrong choice
+			else {
+				return new RefundTO().type(Type.INPUT_MISMATCH);
+			}
 
-    @RequestMapping(value = {"/sign", "/s"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ApiVersion("v2")
-    @ResponseBody
-    public SignTO sign(@RequestBody SignTO input) {
-        final long start = System.currentTimeMillis();
-        if(input.publicKey() == null || input.publicKey().length == 0) {
-            return new SignTO().type(Type.KEYS_NOT_FOUND);
-        }
-        final String key = SerializeUtils.bytesToHex(input.publicKey());
-        try {    
-            LOG.debug("{sign} for {}", key);
-            if(!CONCURRENCY.add(key)) {
-                return new SignTO().type(Type.CONCURRENCY_ERROR);
-            }
-            final SignTO error = ToUtils.checkInput(input);
-            if (error != null) {
-                return error;
-            }
-            final NetworkParameters params = appConfig.getNetworkParameters();
-            final List<ECKey> keys = keyService.getECKeysByClientPublicKey(input.publicKey());
-            if (keys == null || keys.size() != 2) {
-                return new SignTO().type(Type.KEYS_NOT_FOUND);
-            }
+			// sanity check
+			refundTransaction.verify();
 
-            final ECKey serverKey = keys.get(1);
-            final Script redeemScript = BitcoinUtils.createRedeemScript(2, keys);
-            final Script p2SHOutputScript = BitcoinUtils.createP2SHOutputScript(2, keys);
-            Collections.sort(keys, ECKey.PUBKEY_COMPARATOR);
-            final Address p2shAddressFrom = p2SHOutputScript.getToAddress(params);
+			List<TransactionSignature> clientSigs = SerializeUtils.deserializeSignatures(input.clientSignatures());
 
-            final Transaction transaction;
-            //choice 1 - full tx, without sigs
-            if (input.transaction() != null) {
-                LOG.debug("{sign}:{} got transaction from input", (System.currentTimeMillis() - start));
-                transaction = new Transaction(appConfig.getNetworkParameters(), input.transaction());
-            } 
-            //choice 2 - send outpoints, coins, where to send btc to, and amount
-            else if (input.outpointsCoinPair() != null && !input.outpointsCoinPair().isEmpty()
-                    && input.p2shAddressTo() != null && input.amountToSpend() != 0) {
-                //having the coins and the output allows us to create the tx without looking into our wallet
-                try {
-                    transaction = createTx(params, input.p2shAddressTo(), p2shAddressFrom, input.outpointsCoinPair(), 
-                            input.amountToSpend(), redeemScript);
-                } catch (AddressFormatException e) {
-                    LOG.debug("{sign}:{} empty address for", (System.currentTimeMillis() - start));
-                    return new SignTO().type(Type.ADDRESS_EMPTY).message(e.getMessage());
-                }  catch (CoinbleskException e) {
-                    LOG.warn("{sign} could not create tx", e);
-                    return new SignTO().type(Type.TX_ERROR).message(e.getMessage());
-                } catch (InsufficientFunds e) {
-                    LOG.debug("{sign} not enough coins or amount too small");
-                    return new SignTO().type(Type.NOT_ENOUGH_COINS);
-                }
-            } 
-            //wrong choice
-            else {
-                return new SignTO().type(Type.INPUT_MISMATCH);
-            }
-            
-            //sanity check
-            transaction.verify();
-            
-            if(txService.isBurned(params, input.publicKey(), transaction)) {
-                return new SignTO().type(Type.BURNED_OUTPUTS);
-            }
+			// now we can check the client sigs
+			if (!SerializeUtils.verifyTxSignatures(refundTransaction, clientSigs, redeemScript, clientKey)) {
+				LOG.debug("{refund} signature mismatch for tx {} with sigs {}", refundTransaction, clientSigs);
+				return new RefundTO().type(Type.SIGNATURE_ERROR);
+			} else {
+				LOG.debug("{refund} signature good! for tx {} with sigs", refundTransaction, clientSigs);
+			}
+			// also check the server sigs, that the reedemscript has our public
+			// key
 
-            final List<TransactionSignature> serverSigs = BitcoinUtils
-                    .partiallySign(transaction, redeemScript, serverKey);
+			Collections.sort(keys, ECKey.PUBKEY_COMPARATOR);
 
-            final byte[] serializedTransaction = transaction.unsafeBitcoinSerialize();
-            txService.addTransaction(input.publicKey(), serializedTransaction, transaction.getHash().getBytes(), false);
-            LOG.debug("{sign}:tx-hash {} in {} done", transaction.getHash(), (System.currentTimeMillis() - start));
-            return new SignTO()
-                    .setSuccess()
-                    .transaction(serializedTransaction)
-                    .signatures(SerializeUtils.serializeSignatures(serverSigs));
+			List<TransactionSignature> serverSigs = BitcoinUtils.partiallySign(refundTransaction, redeemScript,
+					serverKey);
+			boolean clientFirst = BitcoinUtils.clientFirst(keys, clientKey);
+			BitcoinUtils.applySignatures(refundTransaction, redeemScript, clientSigs, serverSigs, clientFirst);
+			input.serverSignatures(SerializeUtils.serializeSignatures(serverSigs));
+			// TODO: enable
+			// refundTransaction.verify(); make sure those inputs are from the
+			// known p2sh address (min conf)
+			byte[] refundTx = refundTransaction.unsafeBitcoinSerialize();
+			txService.addTransaction(input.publicKey(), refundTx, refundTransaction.getHash().getBytes(), false);
+			LOG.debug("{refund}:{} done", (System.currentTimeMillis() - start));
+			return new RefundTO().setSuccess().refundTransaction(refundTx).serverSignatures(
+					SerializeUtils.serializeSignatures(serverSigs));
+		} catch (Exception e) {
+			LOG.error("register keys error", e);
+			return new RefundTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
 
-        } catch (Exception e) {
-            LOG.error("Sign keys error", e);
-            return new SignTO()
-                    .type(Type.SERVER_ERROR)
-                    .message(e.getMessage());
-        } finally {
-            CONCURRENCY.remove(key);
-        }
-    }
+	@RequestMapping(value = { "/sign",
+			"/s" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ApiVersion("v2")
+	@ResponseBody
+	public SignTO sign(@RequestBody SignTO input) {
+		final long start = System.currentTimeMillis();
+		if (input.publicKey() == null || input.publicKey().length == 0) {
+			return new SignTO().type(Type.KEYS_NOT_FOUND);
+		}
+		final String key = SerializeUtils.bytesToHex(input.publicKey());
+		try {
+			LOG.debug("{sign} for {}", key);
+			if (!CONCURRENCY.add(key)) {
+				return new SignTO().type(Type.CONCURRENCY_ERROR);
+			}
+			final SignTO error = ToUtils.checkInput(input);
+			if (error != null) {
+				return error;
+			}
+			final NetworkParameters params = appConfig.getNetworkParameters();
+			final List<ECKey> keys = keyService.getECKeysByClientPublicKey(input.publicKey());
+			if (keys == null || keys.size() != 2) {
+				return new SignTO().type(Type.KEYS_NOT_FOUND);
+			}
 
-    @RequestMapping(value = {"/verify", "/v"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ApiVersion("v2")
-    @ResponseBody
-    public VerifyTO verify(@RequestBody VerifyTO input) {
-        final long start = System.currentTimeMillis();
-        if(input.publicKey() == null || input.publicKey().length == 0) {
-            return new VerifyTO().type(Type.KEYS_NOT_FOUND);
-        }
-        final String key = SerializeUtils.bytesToHex(input.publicKey());
-        try {
-            LOG.debug("{verify} for {}", key);
-            if(!CONCURRENCY.add(key)) {
-                return new VerifyTO().type(Type.CONCURRENCY_ERROR);
-            }
-            final VerifyTO error = ToUtils.checkInput(input);
-            if (error != null) {
-                return error;
-            }
-            final NetworkParameters params = appConfig.getNetworkParameters();
-            final List<ECKey> keys = keyService.getECKeysByClientPublicKey(input.publicKey());
-            if (keys == null || keys.size() != 2) {
-                return new VerifyTO().type(Type.KEYS_NOT_FOUND);
-            }
-            final ECKey clientKey = keys.get(0);
-            final ECKey serverKey = keys.get(1);
-            final Script redeemScript = BitcoinUtils.createRedeemScript(2, keys);
-            final Script p2SHOutputScript = BitcoinUtils.createP2SHOutputScript(2, keys);
-            Collections.sort(keys, ECKey.PUBKEY_COMPARATOR);
-            final Address p2shAddressFrom = p2SHOutputScript.getToAddress(params);
-            
-            final Transaction fullTx;
-            //choice 1 - full tx
-            if (input.transaction() != null) {
-                LOG.debug("{verify}:{} got transaction from input", (System.currentTimeMillis() - start));
-                fullTx = new Transaction(appConfig.getNetworkParameters(), input.transaction());
-                LOG.debug("{verify}:{} tx1 created {}", (System.currentTimeMillis() - start), fullTx);
-                //TODO: verify that this was sent from us
-            }
-            //choice 2 - send outpoints, coins, where to send btc to, and amount
-            else if (input.outpointsCoinPair() != null && !input.outpointsCoinPair().isEmpty()
-                    && input.p2shAddressTo() != null && input.amountToSpend() != 0 
-                    && input.clientSignatures() != null && input.serverSignatures() != null) {
-                try {
-                    fullTx = createTx(params, input.p2shAddressTo(), p2shAddressFrom, input.outpointsCoinPair(), 
-                            input.amountToSpend(), redeemScript);
-                    List<TransactionSignature> clientSigs = SerializeUtils.deserializeSignatures(
-                            input.clientSignatures());
-                    List<TransactionSignature> severSigs = SerializeUtils.deserializeSignatures(
-                            input.serverSignatures());
-                    final boolean clientFirst = BitcoinUtils.clientFirst(keys, clientKey);
-                    BitcoinUtils.applySignatures(fullTx, redeemScript, clientSigs, severSigs, clientFirst);
-                    
-                    LOG.debug("{verify}:{} tx2 created {}", (System.currentTimeMillis() - start), fullTx);
-                    
-                    if (!SerializeUtils.verifyTxSignatures(fullTx, clientSigs, redeemScript, clientKey)) {
-                        LOG.debug("{verify} signature mismatch for client-sigs tx {} with sigs {}", fullTx, clientSigs);
-                        return new VerifyTO().type(Type.SIGNATURE_ERROR);
-                    } else {
-                        LOG.debug("{verify} signature good! for client-sigs tx {} with sigs", fullTx, clientSigs);
-                    }
-                    
-                    if (!SerializeUtils.verifyTxSignatures(fullTx, severSigs, redeemScript, serverKey)) {
-                        LOG.debug("{verify} signature mismatch for server-sigs tx {} with sigs {}", fullTx, severSigs);
-                        return new VerifyTO().type(Type.SIGNATURE_ERROR);
-                    } else {
-                        LOG.debug("{verify} signature good! for server-sigs tx {} with sigs", fullTx, clientSigs);
-                    }
-                    
-                } catch (AddressFormatException e) {
-                    LOG.debug("{verify}:{} empty address for", (System.currentTimeMillis() - start));
-                    return new VerifyTO().type(Type.ADDRESS_EMPTY).message(e.getMessage());
-                }  catch (CoinbleskException e) {
-                    LOG.warn("{verify} could not create tx", e);
-                    return new VerifyTO().type(Type.SERVER_ERROR).message(e.getMessage());
-                } catch (InsufficientFunds e) {
-                    LOG.debug("{verify} not enough coins or amount too small");
-                    return new VerifyTO().type(Type.NOT_ENOUGH_COINS);
-                }
-            }
-            //wrong choice
-            else {
-                return new VerifyTO().type(Type.INPUT_MISMATCH);
-            }
-            
-            //sanity check
-            fullTx.verify();
-                      
-            final VerifyTO output = new VerifyTO();
-            output.transaction(fullTx.unsafeBitcoinSerialize());
-            
-            LOG.debug("{verify}:{} received {}", (System.currentTimeMillis() - start), fullTx);
+			final ECKey serverKey = keys.get(1);
+			final Script redeemScript = BitcoinUtils.createRedeemScript(2, keys);
+			final Script p2SHOutputScript = BitcoinUtils.createP2SHOutputScript(2, keys);
+			Collections.sort(keys, ECKey.PUBKEY_COMPARATOR);
+			final Address p2shAddressFrom = p2SHOutputScript.getToAddress(params);
 
-            //ok, refunds are locked or no refund found
-            fullTx.getConfidence().setSource(TransactionConfidence.Source.SELF);
-            walletService.receivePending(fullTx);
-            walletService.broadcast(fullTx);
+			final Transaction transaction;
+			// choice 1 - full tx, without sigs
+			if (input.transaction() != null) {
+				LOG.debug("{sign}:{} got transaction from input", (System.currentTimeMillis() - start));
+				transaction = new Transaction(appConfig.getNetworkParameters(), input.transaction());
+			}
+			// choice 2 - send outpoints, coins, where to send btc to, and
+			// amount
+			else if (input.outpointsCoinPair() != null
+					&& !input.outpointsCoinPair().isEmpty()
+					&& input.p2shAddressTo() != null
+					&& input.amountToSpend() != 0) {
+				// having the coins and the output allows us to create the tx
+				// without looking into our wallet
+				try {
+					transaction = createTx(params, input.p2shAddressTo(), p2shAddressFrom, input.outpointsCoinPair(),
+							input.amountToSpend(), redeemScript);
+				} catch (AddressFormatException e) {
+					LOG.debug("{sign}:{} empty address for", (System.currentTimeMillis() - start));
+					return new SignTO().type(Type.ADDRESS_EMPTY).message(e.getMessage());
+				} catch (CoinbleskException e) {
+					LOG.warn("{sign} could not create tx", e);
+					return new SignTO().type(Type.TX_ERROR).message(e.getMessage());
+				} catch (InsufficientFunds e) {
+					LOG.debug("{sign} not enough coins or amount too small");
+					return new SignTO().type(Type.NOT_ENOUGH_COINS);
+				}
+			}
+			// wrong choice
+			else {
+				return new SignTO().type(Type.INPUT_MISMATCH);
+			}
 
-            LOG.debug("{verify}:{} broadcast done", (System.currentTimeMillis() - start));
-            
-            if (txService.isTransactionInstant(params, input.publicKey(), fullTx)) {
-                LOG.debug("{verify}:{} instant payment **OK**", (System.currentTimeMillis() - start));
-                return output.setSuccess();
-            } else {
-                LOG.debug("{verify}:{} instant payment NOTOK", (System.currentTimeMillis() - start));
-                return output.type(Type.SUCCESS_BUT_NO_INSTANT_PAYMENT);
-            }
+			// sanity check
+			transaction.verify();
 
-        } catch (Exception e) {
-            LOG.error("{verify} register keys error: ", e);
-            return new VerifyTO()
-                    .type(Type.SERVER_ERROR)
-                    .message(e.getMessage());
-        } finally {
-            CONCURRENCY.remove(key);
-        }
-    }
-    
-    private static Transaction createTx(NetworkParameters params, String p2shAddressTo, Address p2shAddressFrom,
-            List<Pair<byte[], Long>> outpointsCoinPair, long amountToSpend, Script redeemScript) 
-            throws AddressFormatException, CoinbleskException, InsufficientFunds {
-        final Address p2shAddressTo1 = new Address(params, p2shAddressTo);
+			if (txService.isBurned(params, input.publicKey(), transaction)) {
+				return new SignTO().type(Type.BURNED_OUTPUTS);
+			}
 
-        //we now get from the client the outpoints for the refund tx (including hash)
-        final List<Pair<TransactionOutPoint, Coin>> refundClientPoints = SerializeUtils
-                .deserializeOutPointsCoin(params, outpointsCoinPair);
+			final List<TransactionSignature> serverSigs = BitcoinUtils.partiallySign(transaction, redeemScript,
+					serverKey);
 
-        return BitcoinUtils.createTx(params, refundClientPoints, redeemScript,
-                    p2shAddressFrom, p2shAddressTo1, amountToSpend, true);
-    }
+			final byte[] serializedTransaction = transaction.unsafeBitcoinSerialize();
+			txService.addTransaction(input.publicKey(), serializedTransaction, transaction.getHash().getBytes(), false);
+			LOG.debug("{sign}:tx-hash {} in {} done", transaction.getHash(), (System.currentTimeMillis() - start));
+			return new SignTO().setSuccess().transaction(serializedTransaction).signatures(
+					SerializeUtils.serializeSignatures(serverSigs));
+
+		} catch (Exception e) {
+			LOG.error("Sign keys error", e);
+			return new SignTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		} finally {
+			CONCURRENCY.remove(key);
+		}
+	}
+
+	@RequestMapping(value = { "/verify",
+			"/v" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ApiVersion("v2")
+	@ResponseBody
+	public VerifyTO verify(@RequestBody VerifyTO input) {
+		final long start = System.currentTimeMillis();
+		if (input.publicKey() == null || input.publicKey().length == 0) {
+			return new VerifyTO().type(Type.KEYS_NOT_FOUND);
+		}
+		final String key = SerializeUtils.bytesToHex(input.publicKey());
+		try {
+			LOG.debug("{verify} for {}", key);
+			if (!CONCURRENCY.add(key)) {
+				return new VerifyTO().type(Type.CONCURRENCY_ERROR);
+			}
+			final VerifyTO error = ToUtils.checkInput(input);
+			if (error != null) {
+				return error;
+			}
+			final NetworkParameters params = appConfig.getNetworkParameters();
+			final List<ECKey> keys = keyService.getECKeysByClientPublicKey(input.publicKey());
+			if (keys == null || keys.size() != 2) {
+				return new VerifyTO().type(Type.KEYS_NOT_FOUND);
+			}
+			final ECKey clientKey = keys.get(0);
+			final ECKey serverKey = keys.get(1);
+			final Script redeemScript = BitcoinUtils.createRedeemScript(2, keys);
+			final Script p2SHOutputScript = BitcoinUtils.createP2SHOutputScript(2, keys);
+			Collections.sort(keys, ECKey.PUBKEY_COMPARATOR);
+			final Address p2shAddressFrom = p2SHOutputScript.getToAddress(params);
+
+			final Transaction fullTx;
+			// choice 1 - full tx
+			if (input.transaction() != null) {
+				LOG.debug("{verify}:{} got transaction from input", (System.currentTimeMillis() - start));
+				fullTx = new Transaction(appConfig.getNetworkParameters(), input.transaction());
+				LOG.debug("{verify}:{} tx1 created {}", (System.currentTimeMillis() - start), fullTx);
+				// TODO: verify that this was sent from us
+			}
+			// choice 2 - send outpoints, coins, where to send btc to, and
+			// amount
+			else if (input.outpointsCoinPair() != null
+					&& !input.outpointsCoinPair().isEmpty()
+					&& input.p2shAddressTo() != null
+					&& input.amountToSpend() != 0
+					&& input.clientSignatures() != null
+					&& input.serverSignatures() != null) {
+				try {
+					fullTx = createTx(params, input.p2shAddressTo(), p2shAddressFrom, input.outpointsCoinPair(),
+							input.amountToSpend(), redeemScript);
+					List<TransactionSignature> clientSigs = SerializeUtils.deserializeSignatures(
+							input.clientSignatures());
+					List<TransactionSignature> severSigs = SerializeUtils.deserializeSignatures(
+							input.serverSignatures());
+					final boolean clientFirst = BitcoinUtils.clientFirst(keys, clientKey);
+					BitcoinUtils.applySignatures(fullTx, redeemScript, clientSigs, severSigs, clientFirst);
+
+					LOG.debug("{verify}:{} tx2 created {}", (System.currentTimeMillis() - start), fullTx);
+
+					if (!SerializeUtils.verifyTxSignatures(fullTx, clientSigs, redeemScript, clientKey)) {
+						LOG.debug("{verify} signature mismatch for client-sigs tx {} with sigs {}", fullTx, clientSigs);
+						return new VerifyTO().type(Type.SIGNATURE_ERROR);
+					} else {
+						LOG.debug("{verify} signature good! for client-sigs tx {} with sigs", fullTx, clientSigs);
+					}
+
+					if (!SerializeUtils.verifyTxSignatures(fullTx, severSigs, redeemScript, serverKey)) {
+						LOG.debug("{verify} signature mismatch for server-sigs tx {} with sigs {}", fullTx, severSigs);
+						return new VerifyTO().type(Type.SIGNATURE_ERROR);
+					} else {
+						LOG.debug("{verify} signature good! for server-sigs tx {} with sigs", fullTx, clientSigs);
+					}
+
+				} catch (AddressFormatException e) {
+					LOG.debug("{verify}:{} empty address for", (System.currentTimeMillis() - start));
+					return new VerifyTO().type(Type.ADDRESS_EMPTY).message(e.getMessage());
+				} catch (CoinbleskException e) {
+					LOG.warn("{verify} could not create tx", e);
+					return new VerifyTO().type(Type.SERVER_ERROR).message(e.getMessage());
+				} catch (InsufficientFunds e) {
+					LOG.debug("{verify} not enough coins or amount too small");
+					return new VerifyTO().type(Type.NOT_ENOUGH_COINS);
+				}
+			}
+			// wrong choice
+			else {
+				return new VerifyTO().type(Type.INPUT_MISMATCH);
+			}
+
+			// sanity check
+			fullTx.verify();
+
+			final VerifyTO output = new VerifyTO();
+			output.transaction(fullTx.unsafeBitcoinSerialize());
+
+			LOG.debug("{verify}:{} received {}", (System.currentTimeMillis() - start), fullTx);
+
+			// ok, refunds are locked or no refund found
+			fullTx.getConfidence().setSource(TransactionConfidence.Source.SELF);
+			walletService.receivePending(fullTx);
+			walletService.broadcast(fullTx);
+
+			LOG.debug("{verify}:{} broadcast done", (System.currentTimeMillis() - start));
+
+			if (txService.isTransactionInstant(params, input.publicKey(), fullTx)) {
+				LOG.debug("{verify}:{} instant payment **OK**", (System.currentTimeMillis() - start));
+				return output.setSuccess();
+			} else {
+				LOG.debug("{verify}:{} instant payment NOTOK", (System.currentTimeMillis() - start));
+				return output.type(Type.SUCCESS_BUT_NO_INSTANT_PAYMENT);
+			}
+
+		} catch (Exception e) {
+			LOG.error("{verify} register keys error: ", e);
+			return new VerifyTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		} finally {
+			CONCURRENCY.remove(key);
+		}
+	}
+
+	private static Transaction createTx(NetworkParameters params, String p2shAddressTo, Address p2shAddressFrom,
+			List<Pair<byte[], Long>> outpointsCoinPair, long amountToSpend, Script redeemScript)
+			throws AddressFormatException, CoinbleskException, InsufficientFunds {
+		final Address p2shAddressTo1 = new Address(params, p2shAddressTo);
+
+		// we now get from the client the outpoints for the refund tx (including
+		// hash)
+		final List<Pair<TransactionOutPoint, Coin>> refundClientPoints = SerializeUtils.deserializeOutPointsCoin(params,
+				outpointsCoinPair);
+
+		return BitcoinUtils.createTx(params, refundClientPoints, redeemScript, p2shAddressFrom, p2shAddressTo1,
+				amountToSpend, true);
+	}
 }

--- a/src/main/java/com/coinblesk/server/controller/PaymentController.java
+++ b/src/main/java/com/coinblesk/server/controller/PaymentController.java
@@ -15,6 +15,10 @@
  */
 package com.coinblesk.server.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -37,6 +41,7 @@ import org.bitcoinj.script.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -74,7 +79,7 @@ import com.coinblesk.util.SerializeUtils;
  *
  */
 @RestController
-@RequestMapping(value = { "/payment", "/p" })
+@RequestMapping(value = "/payment")
 @ApiVersion({ "v1", "" })
 public class PaymentController {
 
@@ -93,8 +98,10 @@ public class PaymentController {
 	@Autowired
 	private TransactionService txService;
 
-	@RequestMapping(value = { "/createTimeLockedAddress",
-			"/ctla" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(value = "/createTimeLockedAddress",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public TimeLockedAddressTO createTimeLockedAddress(@RequestBody TimeLockedAddressTO input) {
 		final String tag = "{createTimeLockedAddress}";
@@ -158,8 +165,11 @@ public class PaymentController {
 		}
 	}
 
-	@RequestMapping(value = { "/signverify",
-			"/sv" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/signverify",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public SignVerifyTO signVerify(@RequestBody SignVerifyTO request) {
 		final String tag = "{signverify}";
@@ -313,8 +323,10 @@ public class PaymentController {
 	 * with this UUID for subsequent calls.
 	 *
 	 */
-	@RequestMapping(value = { "/key-exchange",
-			"/x" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(value = "/key-exchange",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public KeyTO keyExchange(@RequestBody KeyTO input) {
 		final long startTime = System.currentTimeMillis();
@@ -362,8 +374,11 @@ public class PaymentController {
 		}
 	}
 
-	@RequestMapping(value = { "/balance",
-			"/b" }, method = RequestMethod.GET, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/balance",
+			method = GET,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public BalanceTO balance(@RequestBody BalanceTO input) {
 		final long start = System.currentTimeMillis();
@@ -395,8 +410,11 @@ public class PaymentController {
 		}
 	}
 
-	@RequestMapping(value = { "/refund",
-			"/r" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/refund",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public RefundTO refund(@RequestBody RefundTO input) {
 		final long start = System.currentTimeMillis();
@@ -482,8 +500,10 @@ public class PaymentController {
 		}
 	}
 
-	@RequestMapping(value = { "/sign",
-			"/s" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(value = "/sign",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ApiVersion("v2")
 	@ResponseBody
 	public SignTO sign(@RequestBody SignTO input) {
@@ -570,8 +590,11 @@ public class PaymentController {
 		}
 	}
 
-	@RequestMapping(value = { "/verify",
-			"/v" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/verify",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ApiVersion("v2")
 	@ResponseBody
 	public VerifyTO verify(@RequestBody VerifyTO input) {

--- a/src/main/java/com/coinblesk/server/controller/PaymentFullTxController.java
+++ b/src/main/java/com/coinblesk/server/controller/PaymentFullTxController.java
@@ -15,15 +15,18 @@
  */
 package com.coinblesk.server.controller;
 
-import com.coinblesk.server.utils.ApiVersion;
-import com.coinblesk.json.v1.SignTO;
-import com.coinblesk.json.v1.VerifyTO;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.coinblesk.json.v1.SignTO;
+import com.coinblesk.json.v1.VerifyTO;
+import com.coinblesk.server.utils.ApiVersion;
 
 /**
  * @deprecated This class is here for compatibility reasons
@@ -32,27 +35,32 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Thomas Bocek
  *
  */
+@Deprecated
 @RestController
-@RequestMapping(value = {"/full-payment", "/f"})
-@ApiVersion({"v1", ""})
+@RequestMapping(value = "/full-payment")
+@ApiVersion({ "v1", "" })
 public class PaymentFullTxController {
 
-    @Autowired
-    private PaymentController paymentController;
+	@Autowired
+	private PaymentController paymentController;
 
-    @RequestMapping(value = {"/sign", "/s"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public SignTO sign(@RequestBody SignTO input) {
-        return paymentController.sign(input);
-    }
+	@RequestMapping(
+			value = "/sign",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
+	@ResponseBody
+	public SignTO sign(@RequestBody SignTO input) {
+		return paymentController.sign(input);
+	}
 
-    @RequestMapping(value = {"/verify", "/v"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public VerifyTO verify(@RequestBody VerifyTO input) {
-        return paymentController.verify(input);
-    }
+	@RequestMapping(
+			value = "/verify",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
+	@ResponseBody
+	public VerifyTO verify(@RequestBody VerifyTO input) {
+		return paymentController.verify(input);
+	}
 }

--- a/src/main/java/com/coinblesk/server/controller/UserController.java
+++ b/src/main/java/com/coinblesk/server/controller/UserController.java
@@ -15,22 +15,10 @@
  */
 package com.coinblesk.server.controller;
 
-import com.coinblesk.bitcoin.BitcoinNet;
-import com.coinblesk.server.auth.JWTConfigurer;
-import com.coinblesk.server.auth.TokenProvider;
-import com.coinblesk.server.dto.LoginDTO;
-import com.coinblesk.server.entity.UserAccount;
-import com.coinblesk.server.service.MailService;
-import com.coinblesk.server.service.UserAccountService;
-import com.coinblesk.server.utils.ApiVersion;
-import com.coinblesk.json.v1.Type;
-import com.coinblesk.json.v1.UserAccountStatusTO;
-import com.coinblesk.json.v1.UserAccountTO;
-import com.coinblesk.server.config.AppConfig;
-import com.coinblesk.util.Pair;
 import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.Locale;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -46,7 +34,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,182 +42,205 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coinblesk.json.v1.Type;
+import com.coinblesk.json.v1.UserAccountStatusTO;
+import com.coinblesk.json.v1.UserAccountTO;
+import com.coinblesk.server.auth.JWTConfigurer;
+import com.coinblesk.server.auth.TokenProvider;
+import com.coinblesk.server.config.AppConfig;
+import com.coinblesk.server.dto.LoginDTO;
+import com.coinblesk.server.entity.UserAccount;
+import com.coinblesk.server.service.MailService;
+import com.coinblesk.server.service.UserAccountService;
+import com.coinblesk.server.utils.ApiVersion;
+import com.coinblesk.util.Pair;
+
 /**
  *
  * @author Thomas Bocek
  */
 @RestController
-@RequestMapping(value = {"/user", "/u"})
-@ApiVersion({"v1", ""})
+@RequestMapping(value = { "/user", "/u" })
+@ApiVersion({ "v1", "" })
 public class UserController {
 
-    private final static Logger LOG = LoggerFactory.getLogger(UserController.class);
+	private final static Logger LOG = LoggerFactory.getLogger(UserController.class);
 
-    @Autowired
-    private UserAccountService userAccountService;
+	@Autowired
+	private UserAccountService userAccountService;
 
-    @Autowired
-    private MailService mailService;
-    
-    @Autowired
-    private MessageSource messageSource;
-    
-    @Autowired
-    private AppConfig cfg;
+	@Autowired
+	private MailService mailService;
 
-    @Autowired
-    private TokenProvider tokenProvider;
+	@Autowired
+	private MessageSource messageSource;
 
-    @Autowired
-    private AuthenticationManager authenticationManager;
+	@Autowired
+	private AppConfig cfg;
 
-    @RequestMapping(value = {"/login", "/l"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    public ResponseEntity<?> login(@Valid @RequestBody LoginDTO loginDTO, HttpServletResponse response) {
+	@Autowired
+	private TokenProvider tokenProvider;
 
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(loginDTO.getUsername().toLowerCase(Locale.ENGLISH),
-                        loginDTO.getPassword());
+	@Autowired
+	private AuthenticationManager authenticationManager;
 
-        try {
-            Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+	@RequestMapping(value = { "/login",
+			"/l" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	public ResponseEntity<?> login(@Valid @RequestBody LoginDTO loginDTO, HttpServletResponse response) {
 
-            String jwt = tokenProvider.createToken(authentication);
-            response.addHeader(JWTConfigurer.AUTHORIZATION_HEADER, "Bearer " + jwt);
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+				loginDTO.getUsername().toLowerCase(Locale.ENGLISH), loginDTO.getPassword());
 
-            return ResponseEntity.ok(Collections.singletonMap("token", jwt));
-        } catch (AuthenticationException exception) {
-            return new ResponseEntity<>(Collections.singletonMap("AuthenticationException",
-                    exception.getLocalizedMessage()), HttpStatus.UNAUTHORIZED);
-        }
-    }
-    
-    //CRUD for the user
-    @RequestMapping(value = {"/create", "/c"}, method = RequestMethod.POST,
-            consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public UserAccountStatusTO createAccount(Locale locale, 
-            @RequestBody UserAccountTO userAccount) {
-        LOG.debug("Create account for {}", userAccount.email());
-        try {
-            //TODO: reactived if deleted flag is set
-            Pair<UserAccountStatusTO, UserAccount> pair = userAccountService.create(userAccount);
-            if ((pair.element0().isSuccess()
-                    || pair.element0().type() == Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED)
-                    && pair.element1() != null && pair.element1().getEmailToken() != null) {
-                
-                try {
-                    LOG.debug("send email to {}", pair.element1().getEmail());
-                    final String path = "v1/user/verify/"+URLEncoder.encode(pair.element1().getEmail(), "UTF-8")+"/"+pair.element1().getEmailToken();
-                    final String url = cfg.getUrl() + path;
-                    mailService.sendUserMail(pair.element1().getEmail(),
-                            messageSource.getMessage("activation.email.title", null, locale), 
-                            messageSource.getMessage("activation.email.text", new String[]{url}, locale));
-                } catch (Exception e) {
-                    LOG.error("Mail send error", e);
-                    mailService.sendAdminMail("Coinblesk Error", "Unexpected Error: " + e);
-                }
-            }
-            return pair.element0();
-        } catch (Exception e) {
-            LOG.error("User create error", e);
-            return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
-        }
-    }
+		try {
+			Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
 
-    @RequestMapping(value = {"/verify/{email}/{token}", "/v/{email}/{token}"}, method = RequestMethod.GET)
-    @ResponseBody
-    public String verifyEmail(@PathVariable(value = "email") String email,
-            @PathVariable(value = "token") String token, HttpServletRequest request) {
-        LOG.debug("Activate account for {}", email);
-        try {
-            UserAccountStatusTO status = userAccountService.activate(email, token);
-            if (!status.isSuccess()) {
-                LOG.error("Someone tried a link with an invalid token: {}/{}/{}", email, token, status.type()
-                        .name());
-                mailService.sendAdminMail("Wrong Link?",
-                        "Someone tried a link with an invalid token: " + email + " / " + token + "/" + status
-                        .type().name());
-                throw new BadRequestException("Wrong Link");
-            }
-            LOG.debug("Activate account success for {}", email);
-            //TODO: text/layout
-            return "Activate account success";
-        } catch (Exception e) {
-            LOG.error("User create error", e);
-            throw new InternalServerErrorException(e);
-        }
-    }
-    
-    //http://stackoverflow.com/questions/16332092/spring-mvc-pathvariable-with-dot-is-getting-truncated
-    @RequestMapping(value = {"/forgot/{email:.+}", "/f/{email:.+}"}, method = RequestMethod.GET)
-    @ResponseBody
-    public UserAccountStatusTO forgot(Locale locale, @PathVariable(value = "email") String email, HttpServletRequest request) {
-        LOG.debug("Forgot password for {}", email);
-        try {
-            Pair<UserAccountStatusTO, UserAccountTO> pair = userAccountService.forgot(email);
-            if(pair.element0().isSuccess()) {
-                 try {
-                    LOG.debug("send forgot email to {}", email);
-                    String forgotToken = pair.element1().message();
-                    String password = pair.element1().password();
-                    final String path = "v1/user/forgot-verify/"+URLEncoder.encode(email, "UTF-8")+"/"+forgotToken;
-                    final String url = cfg.getUrl() + path;
-                    mailService.sendUserMail(email,
-                            messageSource.getMessage("forgot.email.title", null, locale), 
-                            messageSource.getMessage("forgot.email.text", new String[]{url, password}, locale));
-                } catch (Exception e) {
-                    LOG.error("Mail send error", e);
-                    mailService.sendAdminMail("Coinblesk Error", "Unexpected Error: " + e);
-                }
-            }
-            return pair.element0(); 
-        } catch (Exception e) {
-            LOG.error("Forget password error", e);
-            return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
-        }
-    }
-    
-    @RequestMapping(value = {"/forgot-verify/{email}/{forgot-token}", "/fv/{email}/{forgot-token}"}, method = RequestMethod.GET)
-    @ResponseBody
-    public String forgotVerifyEmail(@PathVariable(value = "email") String email,
-            @PathVariable(value = "forgot-token") String forgetToken, HttpServletRequest request) {
-        LOG.debug("Activate account for {}", email);
-        try {
-            UserAccountStatusTO status = userAccountService.activateForgot(email, forgetToken);
-            if (!status.isSuccess()) {
-                LOG.error("Someone tried a link with an invalid forget token: {}/{}/{}", email, forgetToken, status.type()
-                        .name());
-                mailService.sendAdminMail("Wrong Link?",
-                        "Someone tried a link with an invalid forget token: " + email + " / " + forgetToken + "/" + status
-                        .type().name());
-                throw new BadRequestException("Wrong Link");
-            }
-            LOG.debug("Activate forgot password success for {}", email);
-            //TODO: text/layout
-            return "Password reset verify success";
-        } catch (Exception e) {
-            LOG.error("Password reset verify error", e);
-            throw new InternalServerErrorException(e);
-        }
-    }
+			String jwt = tokenProvider.createToken(authentication);
+			response.addHeader(JWTConfigurer.AUTHORIZATION_HEADER, "Bearer " + jwt);
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
-    public class BadRequestException extends RuntimeException {
+			return ResponseEntity.ok(Collections.singletonMap("token", jwt));
+		} catch (AuthenticationException exception) {
+			return new ResponseEntity<>(
+					Collections.singletonMap("AuthenticationException", exception.getLocalizedMessage()),
+					HttpStatus.UNAUTHORIZED);
+		}
+	}
 
-        public BadRequestException(String reason) {
-            super(reason);
-        }
-    }
+	// CRUD for the user
+	@RequestMapping(value = { "/create",
+			"/c" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public UserAccountStatusTO createAccount(Locale locale, @RequestBody UserAccountTO userAccount) {
+		LOG.debug("Create account for {}", userAccount.email());
+		try {
+			// TODO: reactived if deleted flag is set
+			Pair<UserAccountStatusTO, UserAccount> pair = userAccountService.create(userAccount);
+			if ((pair.element0().isSuccess()
+					|| pair.element0().type() == Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED)
+					&& pair.element1() != null
+					&& pair.element1().getEmailToken() != null) {
 
-    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
-    public class InternalServerErrorException extends RuntimeException {
+				try {
+					LOG.debug("send email to {}", pair.element1().getEmail());
+					final String path = "v1/user/verify/"
+							+ URLEncoder.encode(pair.element1().getEmail(), "UTF-8")
+							+ "/"
+							+ pair.element1().getEmailToken();
+					final String url = cfg.getUrl() + path;
+					mailService.sendUserMail(pair.element1().getEmail(),
+							messageSource.getMessage("activation.email.title", null, locale),
+							messageSource.getMessage("activation.email.text", new String[] { url }, locale));
+				} catch (Exception e) {
+					LOG.error("Mail send error", e);
+					mailService.sendAdminMail("Coinblesk Error", "Unexpected Error: " + e);
+				}
+			}
+			return pair.element0();
+		} catch (Exception e) {
+			LOG.error("User create error", e);
+			return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
 
-        public InternalServerErrorException(Throwable t) {
-            super(t);
-        }
-    }
+	@RequestMapping(value = { "/verify/{email}/{token}", "/v/{email}/{token}" }, method = RequestMethod.GET)
+	@ResponseBody
+	public String verifyEmail(@PathVariable(value = "email") String email, @PathVariable(value = "token") String token,
+			HttpServletRequest request) {
+		LOG.debug("Activate account for {}", email);
+		try {
+			UserAccountStatusTO status = userAccountService.activate(email, token);
+			if (!status.isSuccess()) {
+				LOG.error("Someone tried a link with an invalid token: {}/{}/{}", email, token, status.type().name());
+				mailService.sendAdminMail("Wrong Link?", "Someone tried a link with an invalid token: "
+						+ email
+						+ " / "
+						+ token
+						+ "/"
+						+ status.type().name());
+				throw new BadRequestException("Wrong Link");
+			}
+			LOG.debug("Activate account success for {}", email);
+			// TODO: text/layout
+			return "Activate account success";
+		} catch (Exception e) {
+			LOG.error("User create error", e);
+			throw new InternalServerErrorException(e);
+		}
+	}
+
+	// http://stackoverflow.com/questions/16332092/spring-mvc-pathvariable-with-dot-is-getting-truncated
+	@RequestMapping(value = { "/forgot/{email:.+}", "/f/{email:.+}" }, method = RequestMethod.GET)
+	@ResponseBody
+	public UserAccountStatusTO forgot(Locale locale, @PathVariable(value = "email") String email,
+			HttpServletRequest request) {
+		LOG.debug("Forgot password for {}", email);
+		try {
+			Pair<UserAccountStatusTO, UserAccountTO> pair = userAccountService.forgot(email);
+			if (pair.element0().isSuccess()) {
+				try {
+					LOG.debug("send forgot email to {}", email);
+					String forgotToken = pair.element1().message();
+					String password = pair.element1().password();
+					final String path = "v1/user/forgot-verify/"
+							+ URLEncoder.encode(email, "UTF-8")
+							+ "/"
+							+ forgotToken;
+					final String url = cfg.getUrl() + path;
+					mailService.sendUserMail(email, messageSource.getMessage("forgot.email.title", null, locale),
+							messageSource.getMessage("forgot.email.text", new String[] { url, password }, locale));
+				} catch (Exception e) {
+					LOG.error("Mail send error", e);
+					mailService.sendAdminMail("Coinblesk Error", "Unexpected Error: " + e);
+				}
+			}
+			return pair.element0();
+		} catch (Exception e) {
+			LOG.error("Forget password error", e);
+			return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
+
+	@RequestMapping(value = { "/forgot-verify/{email}/{forgot-token}",
+			"/fv/{email}/{forgot-token}" }, method = RequestMethod.GET)
+	@ResponseBody
+	public String forgotVerifyEmail(@PathVariable(value = "email") String email,
+			@PathVariable(value = "forgot-token") String forgetToken, HttpServletRequest request) {
+		LOG.debug("Activate account for {}", email);
+		try {
+			UserAccountStatusTO status = userAccountService.activateForgot(email, forgetToken);
+			if (!status.isSuccess()) {
+				LOG.error("Someone tried a link with an invalid forget token: {}/{}/{}", email, forgetToken,
+						status.type().name());
+				mailService.sendAdminMail("Wrong Link?", "Someone tried a link with an invalid forget token: "
+						+ email
+						+ " / "
+						+ forgetToken
+						+ "/"
+						+ status.type().name());
+				throw new BadRequestException("Wrong Link");
+			}
+			LOG.debug("Activate forgot password success for {}", email);
+			// TODO: text/layout
+			return "Password reset verify success";
+		} catch (Exception e) {
+			LOG.error("Password reset verify error", e);
+			throw new InternalServerErrorException(e);
+		}
+	}
+
+	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	public class BadRequestException extends RuntimeException {
+
+		public BadRequestException(String reason) {
+			super(reason);
+		}
+	}
+
+	@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+	public class InternalServerErrorException extends RuntimeException {
+
+		public InternalServerErrorException(Throwable t) {
+			super(t);
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/controller/UserController.java
+++ b/src/main/java/com/coinblesk/server/controller/UserController.java
@@ -15,6 +15,12 @@
  */
 package com.coinblesk.server.controller;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.Locale;
@@ -37,7 +43,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,7 +65,7 @@ import com.coinblesk.util.Pair;
  * @author Thomas Bocek
  */
 @RestController
-@RequestMapping(value = { "/user", "/u" })
+@RequestMapping(value = "/user")
 @ApiVersion({ "v1", "" })
 public class UserController {
 
@@ -84,8 +89,11 @@ public class UserController {
 	@Autowired
 	private AuthenticationManager authenticationManager;
 
-	@RequestMapping(value = { "/login",
-			"/l" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/login",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<?> login(@Valid @RequestBody LoginDTO loginDTO, HttpServletResponse response) {
 
 		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
@@ -107,8 +115,10 @@ public class UserController {
 	}
 
 	// CRUD for the user
-	@RequestMapping(value = { "/create",
-			"/c" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(value = "/create",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public UserAccountStatusTO createAccount(Locale locale, @RequestBody UserAccountTO userAccount) {
 		LOG.debug("Create account for {}", userAccount.email());
@@ -142,7 +152,9 @@ public class UserController {
 		}
 	}
 
-	@RequestMapping(value = { "/verify/{email}/{token}", "/v/{email}/{token}" }, method = RequestMethod.GET)
+	@RequestMapping(
+			value = "/verify/{email}/{token}",
+			method = GET)
 	@ResponseBody
 	public String verifyEmail(@PathVariable(value = "email") String email, @PathVariable(value = "token") String token,
 			HttpServletRequest request) {
@@ -169,7 +181,9 @@ public class UserController {
 	}
 
 	// http://stackoverflow.com/questions/16332092/spring-mvc-pathvariable-with-dot-is-getting-truncated
-	@RequestMapping(value = { "/forgot/{email:.+}", "/f/{email:.+}" }, method = RequestMethod.GET)
+	@RequestMapping(
+			value = "/forgot/{email:.+}",
+			method = GET)
 	@ResponseBody
 	public UserAccountStatusTO forgot(Locale locale, @PathVariable(value = "email") String email,
 			HttpServletRequest request) {
@@ -200,8 +214,9 @@ public class UserController {
 		}
 	}
 
-	@RequestMapping(value = { "/forgot-verify/{email}/{forgot-token}",
-			"/fv/{email}/{forgot-token}" }, method = RequestMethod.GET)
+	@RequestMapping(
+			value = "/forgot-verify/{email}/{forgot-token}",
+			method = GET)
 	@ResponseBody
 	public String forgotVerifyEmail(@PathVariable(value = "email") String email,
 			@PathVariable(value = "forgot-token") String forgetToken, HttpServletRequest request) {
@@ -228,7 +243,7 @@ public class UserController {
 		}
 	}
 
-	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	@ResponseStatus(value = BAD_REQUEST)
 	public class BadRequestException extends RuntimeException {
 
 		public BadRequestException(String reason) {
@@ -236,7 +251,7 @@ public class UserController {
 		}
 	}
 
-	@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+	@ResponseStatus(value = INTERNAL_SERVER_ERROR)
 	public class InternalServerErrorException extends RuntimeException {
 
 		public InternalServerErrorException(Throwable t) {

--- a/src/main/java/com/coinblesk/server/controller/UserControllerAuthenticated.java
+++ b/src/main/java/com/coinblesk/server/controller/UserControllerAuthenticated.java
@@ -15,6 +15,11 @@
  */
 package com.coinblesk.server.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.PATCH;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -27,7 +32,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,7 +48,7 @@ import com.coinblesk.server.utils.ApiVersion;
  * @author Thomas Bocek
  */
 @RestController
-@RequestMapping(value = { "/user/a", "/user/auth", "/u/auth", "/u/a" })
+@RequestMapping(value = "/user/auth")
 @ApiVersion({ "v1" })
 public class UserControllerAuthenticated {
 
@@ -56,8 +60,10 @@ public class UserControllerAuthenticated {
 	@Autowired
 	private MailService mailService;
 
-	@RequestMapping(value = { "/delete",
-			"/d" }, method = RequestMethod.PATCH, produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/delete",
+			method = PATCH,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public UserAccountStatusTO deleteAccount() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -74,13 +80,17 @@ public class UserControllerAuthenticated {
 			}
 			LOG.debug("Delete account success for {}", auth.getName());
 			return status;
+
 		} catch (Exception e) {
 			LOG.error("User create error", e);
 			return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
 		}
 	}
 
-	@RequestMapping(value = { "/get", "/g" }, method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/get",
+			method = GET,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public UserAccountTO getAccount() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -102,8 +112,10 @@ public class UserControllerAuthenticated {
 		}
 	}
 
-	@RequestMapping(value = { "/transfer-p2sh",
-			"/t" }, method = RequestMethod.POST, produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/transfer-p2sh",
+			method = POST,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public UserAccountTO transferToP2SH(@RequestBody BaseTO request) {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -123,7 +135,10 @@ public class UserControllerAuthenticated {
 		}
 	}
 
-	@RequestMapping(value = "/logout", method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/logout",
+			method = GET,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	public UserAccountStatusTO logout(HttpServletRequest request, HttpServletResponse response) {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		LOG.debug("Logout account for {}", auth.getName());
@@ -133,7 +148,11 @@ public class UserControllerAuthenticated {
 		return new UserAccountStatusTO().setSuccess();
 	}
 
-	@RequestMapping(value = "/change-password", method = RequestMethod.POST, produces = "application/json; charset=UTF-8", consumes = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "/change-password",
+			method = POST,
+			produces = APPLICATION_JSON_UTF8_VALUE,
+			consumes = APPLICATION_JSON_UTF8_VALUE)
 	public UserAccountStatusTO changePassword(@RequestBody UserAccountTO to, HttpServletRequest request,
 			HttpServletResponse response) {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/coinblesk/server/controller/UserControllerAuthenticated.java
+++ b/src/main/java/com/coinblesk/server/controller/UserControllerAuthenticated.java
@@ -15,15 +15,9 @@
  */
 package com.coinblesk.server.controller;
 
-import com.coinblesk.json.v1.BaseTO;
-import com.coinblesk.server.service.MailService;
-import com.coinblesk.server.service.UserAccountService;
-import com.coinblesk.server.utils.ApiVersion;
-import com.coinblesk.json.v1.Type;
-import com.coinblesk.json.v1.UserAccountStatusTO;
-import com.coinblesk.json.v1.UserAccountTO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.bitcoinj.core.ECKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,116 +31,120 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coinblesk.json.v1.BaseTO;
+import com.coinblesk.json.v1.Type;
+import com.coinblesk.json.v1.UserAccountStatusTO;
+import com.coinblesk.json.v1.UserAccountTO;
+import com.coinblesk.server.service.MailService;
+import com.coinblesk.server.service.UserAccountService;
+import com.coinblesk.server.utils.ApiVersion;
+
 /**
  *
  * @author Thomas Bocek
  */
 @RestController
-@RequestMapping(value = {"/user/a", "/user/auth", "/u/auth", "/u/a"})
-@ApiVersion({"v1"})
+@RequestMapping(value = { "/user/a", "/user/auth", "/u/auth", "/u/a" })
+@ApiVersion({ "v1" })
 public class UserControllerAuthenticated {
 
-    private final static Logger LOG = LoggerFactory.getLogger(UserControllerAuthenticated.class);
+	private final static Logger LOG = LoggerFactory.getLogger(UserControllerAuthenticated.class);
 
-    @Autowired
-    private UserAccountService userAccountService;
+	@Autowired
+	private UserAccountService userAccountService;
 
-    @Autowired
-    private MailService mailService;
+	@Autowired
+	private MailService mailService;
 
-    @RequestMapping(value = {"/delete", "/d"}, method = RequestMethod.PATCH,
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public UserAccountStatusTO deleteAccount() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        LOG.debug("Delete account for {}", auth.getName());
-        try {
-            UserAccountStatusTO status = userAccountService.delete(auth.getName());
-            if (!status.isSuccess()) {
-                LOG.error("Someone tried a delete account with an invalid username: {}/{}", auth, status
-                        .type().name());
-                mailService.sendAdminMail("Wrong Delete Account?",
-                        "Someone tried a delete account with an invalid username: " + auth + "/" + status
-                        .type().name());
-            }
-            LOG.debug("Delete account success for {}", auth.getName());
-            return status;
-        } catch (Exception e) {
-            LOG.error("User create error", e);
-            return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
-        }
-    }
+	@RequestMapping(value = { "/delete",
+			"/d" }, method = RequestMethod.PATCH, produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public UserAccountStatusTO deleteAccount() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		LOG.debug("Delete account for {}", auth.getName());
+		try {
+			UserAccountStatusTO status = userAccountService.delete(auth.getName());
+			if (!status.isSuccess()) {
+				LOG.error("Someone tried a delete account with an invalid username: {}/{}", auth, status.type().name());
+				mailService.sendAdminMail("Wrong Delete Account?",
+						"Someone tried a delete account with an invalid username: "
+								+ auth
+								+ "/"
+								+ status.type().name());
+			}
+			LOG.debug("Delete account success for {}", auth.getName());
+			return status;
+		} catch (Exception e) {
+			LOG.error("User create error", e);
+			return new UserAccountStatusTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
 
-    @RequestMapping(value = {"/get", "/g"}, method = RequestMethod.GET,
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public UserAccountTO getAccount() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        LOG.debug("Get account for {}", auth.getName());
-        try {
-            
-            UserAccountTO userAccount = userAccountService.get(auth.getName());
-            if (userAccount == null) {
-                LOG.error("Someone tried to access an account with an invalid username: {}", auth);
-                mailService.sendAdminMail("Wrong Account?",
-                        "Someone tried to access an account with an invalid username: " + auth);
-                return null;
-            }
-            LOG.debug("Get account success for {}", auth.getName());
-            return userAccount;
-        } catch (Exception e) {
-            LOG.error("User create error", e);
-            return new UserAccountTO().type(Type.SERVER_ERROR).message(e.getMessage());
-        }
-    }
-    
-    @RequestMapping(value = {"/transfer-p2sh", "/t"}, method = RequestMethod.POST,
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public UserAccountTO transferToP2SH(@RequestBody BaseTO request) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        LOG.debug("Get account for {}", auth.getName());
-        try {
-            final ECKey clientKey = ECKey.fromPublicOnly(request.publicKey());
-            UserAccountTO status = userAccountService.transferP2SH(clientKey, auth.getName());
-            if(status != null) {
-                LOG.debug("Transfer P2SH success for {}, tx:{}", auth.getName(), status.message());
-                return status;
-            } else {
-                return new UserAccountTO().type(Type.ACCOUNT_ERROR); 
-            }
-        } catch (Exception e) {
-            LOG.error("User create error", e);
-            return new UserAccountTO().type(Type.SERVER_ERROR).message(e.getMessage());
-        }
-    }
-    
-    @RequestMapping(value="/logout", method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
-    public UserAccountStatusTO logout (HttpServletRequest request, HttpServletResponse response) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        LOG.debug("Logout account for {}", auth.getName());
-        if (auth != null) {
-            new SecurityContextLogoutHandler().logout(request, response, auth);
-        }
-        return new UserAccountStatusTO().setSuccess();
-    }
-    
-    @RequestMapping(value="/change-password", method = RequestMethod.POST, 
-            produces = "application/json; charset=UTF-8", 
-            consumes = "application/json; charset=UTF-8")
-    public UserAccountStatusTO changePassword (
-            @RequestBody UserAccountTO to, 
-            HttpServletRequest request, 
-            HttpServletResponse response) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        LOG.debug("Change password account for {}", auth.getName());
-        if (auth != null) {
-            UserAccountStatusTO status = userAccountService.changePassword(auth.getName(), to.password());
-            return status;
-        } else {
-            return new UserAccountStatusTO().type(Type.ACCOUNT_ERROR);
-        }
-        
-    }
-    
+	@RequestMapping(value = { "/get", "/g" }, method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public UserAccountTO getAccount() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		LOG.debug("Get account for {}", auth.getName());
+		try {
+
+			UserAccountTO userAccount = userAccountService.get(auth.getName());
+			if (userAccount == null) {
+				LOG.error("Someone tried to access an account with an invalid username: {}", auth);
+				mailService.sendAdminMail("Wrong Account?",
+						"Someone tried to access an account with an invalid username: " + auth);
+				return null;
+			}
+			LOG.debug("Get account success for {}", auth.getName());
+			return userAccount;
+		} catch (Exception e) {
+			LOG.error("User create error", e);
+			return new UserAccountTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
+
+	@RequestMapping(value = { "/transfer-p2sh",
+			"/t" }, method = RequestMethod.POST, produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public UserAccountTO transferToP2SH(@RequestBody BaseTO request) {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		LOG.debug("Get account for {}", auth.getName());
+		try {
+			final ECKey clientKey = ECKey.fromPublicOnly(request.publicKey());
+			UserAccountTO status = userAccountService.transferP2SH(clientKey, auth.getName());
+			if (status != null) {
+				LOG.debug("Transfer P2SH success for {}, tx:{}", auth.getName(), status.message());
+				return status;
+			} else {
+				return new UserAccountTO().type(Type.ACCOUNT_ERROR);
+			}
+		} catch (Exception e) {
+			LOG.error("User create error", e);
+			return new UserAccountTO().type(Type.SERVER_ERROR).message(e.getMessage());
+		}
+	}
+
+	@RequestMapping(value = "/logout", method = RequestMethod.GET, produces = "application/json; charset=UTF-8")
+	public UserAccountStatusTO logout(HttpServletRequest request, HttpServletResponse response) {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		LOG.debug("Logout account for {}", auth.getName());
+		if (auth != null) {
+			new SecurityContextLogoutHandler().logout(request, response, auth);
+		}
+		return new UserAccountStatusTO().setSuccess();
+	}
+
+	@RequestMapping(value = "/change-password", method = RequestMethod.POST, produces = "application/json; charset=UTF-8", consumes = "application/json; charset=UTF-8")
+	public UserAccountStatusTO changePassword(@RequestBody UserAccountTO to, HttpServletRequest request,
+			HttpServletResponse response) {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		LOG.debug("Change password account for {}", auth.getName());
+		if (auth != null) {
+			UserAccountStatusTO status = userAccountService.changePassword(auth.getName(), to.password());
+			return status;
+		} else {
+			return new UserAccountStatusTO().type(Type.ACCOUNT_ERROR);
+		}
+
+	}
+
 }

--- a/src/main/java/com/coinblesk/server/controller/VersionController.java
+++ b/src/main/java/com/coinblesk/server/controller/VersionController.java
@@ -39,57 +39,47 @@ import com.coinblesk.server.config.AppConfig;
 import com.coinblesk.server.utils.ApiVersion;
 import com.coinblesk.util.CoinbleskException;
 
-
 /**
  * @author Andreas Albrecht
  */
 @RestController
-@RequestMapping(value = {"/version", "/v"})
-@ApiVersion({"v1"})
+@RequestMapping(value = { "/version", "/v" })
+@ApiVersion({ "v1" })
 public class VersionController {
-	
+
 	private final static Logger LOG = LoggerFactory.getLogger(VersionController.class);
-		
+
 	@Autowired
-    private ServletContext context;
-	
+	private ServletContext context;
+
 	@Autowired
 	private AppConfig appConfig;
-	
-	@RequestMapping(
-    		value = {""},
-    		method = RequestMethod.POST,
-    		consumes = "application/json; charset=UTF-8",
-            produces = "application/json; charset=UTF-8")
-    @ResponseBody
-    public VersionTO version(@RequestBody VersionTO input) {
+
+	@RequestMapping(value = {
+			"" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@ResponseBody
+	public VersionTO version(@RequestBody VersionTO input) {
 		final String tag = "{version}";
 		final Instant startTime = Instant.now();
-		
+
 		try {
 			final String serverVersion = getServerVersion();
 			final BitcoinNet serverNetwork = appConfig.getBitcoinNet();
 			final String clientVersion = input.clientVersion();
 			final BitcoinNet clientNetwork = input.bitcoinNet();
-						
+
 			if (clientVersion == null || clientVersion.isEmpty() || clientNetwork == null) {
 				return new VersionTO().type(Type.INPUT_MISMATCH);
 			}
-			
-			final boolean isSupported = isVersionSupported(clientVersion) && 
-										isNetworkSupported(clientNetwork);
-			LOG.debug("{} - serverVersion={}, serverNetwork={}, clientVersion={}, clientNetwork={}, isSupported={}", 
+
+			final boolean isSupported = isVersionSupported(clientVersion) && isNetworkSupported(clientNetwork);
+			LOG.debug("{} - serverVersion={}, serverNetwork={}, clientVersion={}, clientNetwork={}, isSupported={}",
 					tag, serverVersion, serverNetwork, clientVersion, clientNetwork, isSupported);
-			
-			return new VersionTO()
-					.bitcoinNet(serverNetwork)
-					.setSupported(isSupported)
-					.setSuccess();
+
+			return new VersionTO().bitcoinNet(serverNetwork).setSupported(isSupported).setSuccess();
 		} catch (Exception e) {
 			LOG.error("{} - failed with exception: ", tag, e);
-			return new VersionTO()
-					.type(Type.SERVER_ERROR)
-					.message(e.getMessage());
+			return new VersionTO().type(Type.SERVER_ERROR).message(e.getMessage());
 		} finally {
 			LOG.debug("{} - finished in {} ms", tag, Duration.between(startTime, Instant.now()).toMillis());
 		}
@@ -101,22 +91,23 @@ public class VersionController {
 
 	/**
 	 * Extracts the Version property from the manifest.
-	 * 
-	 * @return the version iff run as war packaged application. Otherwise, (UNKNOWN) is returned.
+	 *
+	 * @return the version iff run as war packaged application. Otherwise,
+	 *         (UNKNOWN) is returned.
 	 * @throws CoinbleskException
 	 */
 	private String getServerVersion() throws CoinbleskException {
-        // see: build.gradle
-    	final String versionKey = "Version";
-    	final String defaultVersion = "(UNKNOWN)";
-    	InputStream inputStream = null;
+		// see: build.gradle
+		final String versionKey = "Version";
+		final String defaultVersion = "(UNKNOWN)";
+		InputStream inputStream = null;
 		try {
 			inputStream = context.getResourceAsStream("/META-INF/MANIFEST.MF");
 			if (inputStream == null) {
 				LOG.warn("Manifest resource not found (inputStream=null, maybe not run as war file?).");
 				return defaultVersion;
 			}
-			
+
 			Properties prop = new Properties();
 			prop.load(inputStream);
 			if (prop.containsKey(versionKey)) {
@@ -135,7 +126,7 @@ public class VersionController {
 				}
 			}
 		}
-        return defaultVersion;
+		return defaultVersion;
 	}
 
 	private boolean isVersionSupported(String clientVersion) {

--- a/src/main/java/com/coinblesk/server/controller/VersionController.java
+++ b/src/main/java/com/coinblesk/server/controller/VersionController.java
@@ -15,6 +15,9 @@
  */
 package com.coinblesk.server.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -28,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,7 +45,7 @@ import com.coinblesk.util.CoinbleskException;
  * @author Andreas Albrecht
  */
 @RestController
-@RequestMapping(value = { "/version", "/v" })
+@RequestMapping(value = "/version")
 @ApiVersion({ "v1" })
 public class VersionController {
 
@@ -55,8 +57,11 @@ public class VersionController {
 	@Autowired
 	private AppConfig appConfig;
 
-	@RequestMapping(value = {
-			"" }, method = RequestMethod.POST, consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+	@RequestMapping(
+			value = "",
+			method = POST,
+			consumes = APPLICATION_JSON_UTF8_VALUE,
+			produces = APPLICATION_JSON_UTF8_VALUE)
 	@ResponseBody
 	public VersionTO version(@RequestBody VersionTO input) {
 		final String tag = "{version}";

--- a/src/main/java/com/coinblesk/server/dao/KeyRepository.java
+++ b/src/main/java/com/coinblesk/server/dao/KeyRepository.java
@@ -1,9 +1,9 @@
 package com.coinblesk.server.dao;
 
-import com.coinblesk.server.entity.Keys;
 import org.springframework.data.repository.CrudRepository;
 
-public interface KeyRepository extends CrudRepository<Keys, Long>
-{
-    Keys findByClientPublicKey(final byte[] clientPublicKey);
+import com.coinblesk.server.entity.Keys;
+
+public interface KeyRepository extends CrudRepository<Keys, Long> {
+	Keys findByClientPublicKey(final byte[] clientPublicKey);
 }

--- a/src/main/java/com/coinblesk/server/dao/TimeLockedAddressRepository.java
+++ b/src/main/java/com/coinblesk/server/dao/TimeLockedAddressRepository.java
@@ -1,12 +1,14 @@
 package com.coinblesk.server.dao;
 
-import com.coinblesk.server.entity.TimeLockedAddressEntity;
-import org.springframework.data.repository.CrudRepository;
-
 import java.util.List;
 
-public interface TimeLockedAddressRepository extends CrudRepository<TimeLockedAddressEntity, Long>
-{
-    TimeLockedAddressEntity findByAddressHash(byte[] addressHash);
-    List<TimeLockedAddressEntity> findByKeys_ClientPublicKey(byte[] clientPublicKey);
+import org.springframework.data.repository.CrudRepository;
+
+import com.coinblesk.server.entity.TimeLockedAddressEntity;
+
+public interface TimeLockedAddressRepository extends CrudRepository<TimeLockedAddressEntity, Long> {
+
+	TimeLockedAddressEntity findByAddressHash(byte[] addressHash);
+
+	List<TimeLockedAddressEntity> findByKeys_ClientPublicKey(byte[] clientPublicKey);
 }

--- a/src/main/java/com/coinblesk/server/dao/TxQueueRepository.java
+++ b/src/main/java/com/coinblesk/server/dao/TxQueueRepository.java
@@ -1,8 +1,8 @@
 package com.coinblesk.server.dao;
 
-import com.coinblesk.server.entity.TxQueue;
 import org.springframework.data.repository.CrudRepository;
 
-public interface TxQueueRepository extends CrudRepository<TxQueue, byte[]>
-{
+import com.coinblesk.server.entity.TxQueue;
+
+public interface TxQueueRepository extends CrudRepository<TxQueue, byte[]> {
 }

--- a/src/main/java/com/coinblesk/server/dao/TxRepository.java
+++ b/src/main/java/com/coinblesk/server/dao/TxRepository.java
@@ -1,12 +1,14 @@
 package com.coinblesk.server.dao;
 
-import com.coinblesk.server.entity.Tx;
-import org.springframework.data.repository.CrudRepository;
-
 import java.util.List;
 
-public interface TxRepository extends CrudRepository<Tx, byte[]>
-{
-    List<Tx> findByClientPublicKeyAndApproved(final byte[] clientPublicKey, final boolean approved);
-    List<Tx> findByApproved(final boolean approved);
+import org.springframework.data.repository.CrudRepository;
+
+import com.coinblesk.server.entity.Tx;
+
+public interface TxRepository extends CrudRepository<Tx, byte[]> {
+
+	List<Tx> findByClientPublicKeyAndApproved(final byte[] clientPublicKey, final boolean approved);
+
+	List<Tx> findByApproved(final boolean approved);
 }

--- a/src/main/java/com/coinblesk/server/dao/UserAccountRepository.java
+++ b/src/main/java/com/coinblesk/server/dao/UserAccountRepository.java
@@ -1,14 +1,14 @@
 package com.coinblesk.server.dao;
 
-import com.coinblesk.server.entity.UserAccount;
-import org.springframework.data.repository.CrudRepository;
-
-import java.util.List;
 import java.util.Optional;
 
-public interface UserAccountRepository extends CrudRepository<UserAccount, Long>
-{
-    Optional<UserAccount> findOptionalByEmail(String email);
+import org.springframework.data.repository.CrudRepository;
 
-    UserAccount findByEmail(String email);
+import com.coinblesk.server.entity.UserAccount;
+
+public interface UserAccountRepository extends CrudRepository<UserAccount, Long> {
+
+	Optional<UserAccount> findOptionalByEmail(String email);
+
+	UserAccount findByEmail(String email);
 }

--- a/src/main/java/com/coinblesk/server/dto/LoginDTO.java
+++ b/src/main/java/com/coinblesk/server/dto/LoginDTO.java
@@ -1,39 +1,37 @@
 package com.coinblesk.server.dto;
 
-import com.coinblesk.server.service.UserAccountService;
+import static com.coinblesk.server.service.UserAccountService.EMAIL_PATTERN;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 public class LoginDTO {
 
-    @Pattern(regexp = UserAccountService.EMAIL_PATTERN)
-    @NotNull
-    private String username;
+	@Pattern(regexp = EMAIL_PATTERN)
+	@NotNull
+	private String username;
 
-    @NotNull
-    private String password;
+	@NotNull
+	private String password;
 
-    public String getUsername() {
-        return username;
-    }
+	public String getUsername() {
+		return username;
+	}
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
+	public void setUsername(String username) {
+		this.username = username;
+	}
 
-    public String getPassword() {
-        return password;
-    }
+	public String getPassword() {
+		return password;
+	}
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
+	public void setPassword(String password) {
+		this.password = password;
+	}
 
-    @Override
-    public String toString() {
-        return "LoginDTO{" +
-                "password='*****'" +
-                ", username='" + username + "'}";
-    }
+	@Override
+	public String toString() {
+		return "LoginDTO{" + "password='*****'" + ", username='" + username + "'}";
+	}
 }

--- a/src/main/java/com/coinblesk/server/entity/Keys.java
+++ b/src/main/java/com/coinblesk/server/entity/Keys.java
@@ -29,88 +29,85 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 
-
 /**
  *
  * @author Thomas Bocek
  */
 @Entity(name = "KEYS")
-@Table(indexes = {
-		@Index(name = "KEYS_CLIENT_PUBLIC_KEY", columnList = "CLIENT_PUBLIC_KEY")
-})
+@Table(indexes = { @Index(name = "KEYS_CLIENT_PUBLIC_KEY", columnList = "CLIENT_PUBLIC_KEY") })
 public class Keys implements Serializable {
 
-    private static final long serialVersionUID = -7496348013847426913L;
+	private static final long serialVersionUID = -7496348013847426913L;
 
-    @Id
-    @GeneratedValue(strategy=GenerationType.SEQUENCE)
-    private long id;
-    
-    @Column(name = "CLIENT_PUBLIC_KEY", unique = true, nullable = false, updatable = false, length = 255)
-    private byte[] clientPublicKey;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	private long id;
 
-    @Column(name = "SERVER_PUBLIC_KEY", unique = true, nullable = false, updatable = false, length = 255)
-    private byte[] serverPublicKey;
+	@Column(name = "CLIENT_PUBLIC_KEY", unique = true, nullable = false, updatable = false, length = 255)
+	private byte[] clientPublicKey;
 
-    @Column(name = "SERVER_PRIVATE_KEY", unique = true, nullable = false, updatable = false, length = 255)
-    private byte[] serverPrivateKey;
+	@Column(name = "SERVER_PUBLIC_KEY", unique = true, nullable = false, updatable = false, length = 255)
+	private byte[] serverPublicKey;
 
-    @Column(name = "TIME_CREATED", updatable = false, nullable = false)
-    private long timeCreated;
-    
-    @OneToMany(mappedBy="keys", fetch = FetchType.EAGER)
-    @OrderBy("TIME_CREATED ASC")
-    private List<TimeLockedAddressEntity> timeLockedAddresses; 
-    
-    public byte[] clientPublicKey() {
-        return clientPublicKey;
-    }
+	@Column(name = "SERVER_PRIVATE_KEY", unique = true, nullable = false, updatable = false, length = 255)
+	private byte[] serverPrivateKey;
 
-    public Keys clientPublicKey(byte[] clientPublicKey) {
-        this.clientPublicKey = clientPublicKey;
-        return this;
-    }
+	@Column(name = "TIME_CREATED", updatable = false, nullable = false)
+	private long timeCreated;
 
-    public byte[] serverPublicKey() {
-        return serverPublicKey;
-    }
+	@OneToMany(mappedBy = "keys", fetch = FetchType.EAGER)
+	@OrderBy("TIME_CREATED ASC")
+	private List<TimeLockedAddressEntity> timeLockedAddresses;
 
-    public Keys serverPublicKey(byte[] serverPublicKey) {
-        this.serverPublicKey = serverPublicKey;
-        return this;
-    }
+	public byte[] clientPublicKey() {
+		return clientPublicKey;
+	}
 
-    public byte[] serverPrivateKey() {
-        return serverPrivateKey;
-    }
+	public Keys clientPublicKey(byte[] clientPublicKey) {
+		this.clientPublicKey = clientPublicKey;
+		return this;
+	}
 
-    public Keys serverPrivateKey(byte[] serverPrivateKey) {
-        this.serverPrivateKey = serverPrivateKey;
-        return this;
-    }
-    
-    public long timeCreated() {
-    	return timeCreated;
-    }
-    
-    public Keys timeCreated(long timeCreatedSeconds) {
-    	this.timeCreated = timeCreatedSeconds;
-    	return this;
-    }
+	public byte[] serverPublicKey() {
+		return serverPublicKey;
+	}
 
-    public List<TimeLockedAddressEntity> timeLockedAddresses() {
-    	return timeLockedAddresses;
-    }
-    
-    public TimeLockedAddressEntity latestTimeLockedAddresses() {
-    	return timeLockedAddresses.get(timeLockedAddresses.size() - 1);
-    }
-    
-    public Keys timeLockedAddresses(List<TimeLockedAddressEntity> timeLockedAddresses) {
-	this.timeLockedAddresses = timeLockedAddresses;
-	return this;
-    }
-	
+	public Keys serverPublicKey(byte[] serverPublicKey) {
+		this.serverPublicKey = serverPublicKey;
+		return this;
+	}
+
+	public byte[] serverPrivateKey() {
+		return serverPrivateKey;
+	}
+
+	public Keys serverPrivateKey(byte[] serverPrivateKey) {
+		this.serverPrivateKey = serverPrivateKey;
+		return this;
+	}
+
+	public long timeCreated() {
+		return timeCreated;
+	}
+
+	public Keys timeCreated(long timeCreatedSeconds) {
+		this.timeCreated = timeCreatedSeconds;
+		return this;
+	}
+
+	public List<TimeLockedAddressEntity> timeLockedAddresses() {
+		return timeLockedAddresses;
+	}
+
+	public TimeLockedAddressEntity latestTimeLockedAddresses() {
+		return timeLockedAddresses.get(timeLockedAddresses.size() - 1);
+	}
+
+	public Keys timeLockedAddresses(List<TimeLockedAddressEntity> timeLockedAddresses) {
+		this.timeLockedAddresses = timeLockedAddresses;
+		return this;
+	}
+
 	/*public List<Address> btcAddresses(NetworkParameters params) {
 		List<Address> addressList = new ArrayList<>(addresses.size());
 		for (TimeLockedAddressEntity e : addresses) {

--- a/src/main/java/com/coinblesk/server/entity/TimeLockedAddressEntity.java
+++ b/src/main/java/com/coinblesk/server/entity/TimeLockedAddressEntity.java
@@ -18,14 +18,11 @@ package com.coinblesk.server.entity;
 import java.util.Comparator;
 
 import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -37,91 +34,88 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 
 @Entity(name = "TIME_LOCKED_ADDRESS")
-@Table(indexes = {
-	    @Index(name = "ADDRESS_HASH_INDEX", columnList = "ADDRESS_HASH", unique = true)})
+@Table(indexes = { @Index(name = "ADDRESS_HASH_INDEX", columnList = "ADDRESS_HASH", unique = true) })
 public class TimeLockedAddressEntity {
-	
+
 	@Id
-	@Column(name = "ID", nullable = false, unique=true, updatable = false)
-	@GeneratedValue(strategy=GenerationType.SEQUENCE)
+	@Column(name = "ID", nullable = false, unique = true, updatable = false)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE)
 	private long id;
-	
+
 	@ManyToOne
-    @JoinColumn(name="KEYS_FK")
-    private Keys keys;
-	
-	@Column(name="TIME_CREATED", nullable = false, updatable = false)
+	@JoinColumn(name = "KEYS_FK")
+	private Keys keys;
+
+	@Column(name = "TIME_CREATED", nullable = false, updatable = false)
 	private long timeCreated;
-	
-	@Column(name="ADDRESS_HASH", nullable = false, unique=true, updatable = false, length=255)
+
+	@Column(name = "ADDRESS_HASH", nullable = false, unique = true, updatable = false, length = 255)
 	private byte[] addressHash;
-	
-	@Column(name="REDEEM_SCRIPT", nullable = false, updatable = false, length=4096)
+
+	@Column(name = "REDEEM_SCRIPT", nullable = false, updatable = false, length = 4096)
 	private byte[] redeemScript;
-        
-    @Column(name="LOCK_TIME", nullable = false, updatable = false)
+
+	@Column(name = "LOCK_TIME", nullable = false, updatable = false)
 	private long lockTime;
-	
+
 	public long getId() {
 		return id;
 	}
-	
+
 	public TimeLockedAddressEntity setId(long id) {
 		this.id = id;
 		return this;
 	}
-	
+
 	public Keys getKeys() {
 		return keys;
 	}
-	
+
 	public TimeLockedAddressEntity setKeys(Keys keys) {
 		this.keys = keys;
 		return this;
 	}
-	
+
 	public long getTimeCreated() {
 		return timeCreated;
 	}
-	
+
 	public TimeLockedAddressEntity setTimeCreated(long timeCreatedSeconds) {
 		this.timeCreated = timeCreatedSeconds;
 		return this;
 	}
-	
+
 	public byte[] getAddressHash() {
 		return addressHash;
 	}
-	
+
 	public TimeLockedAddressEntity setAddressHash(byte[] addressHash) {
 		this.addressHash = addressHash;
 		return this;
 	}
-	
+
 	public byte[] getRedeemScript() {
 		return redeemScript;
 	}
-	
+
 	public TimeLockedAddressEntity setRedeemScript(byte[] redeemScript) {
 		this.redeemScript = redeemScript;
 		return this;
 	}
-	
+
 	public Address toAddress(NetworkParameters params) {
 		return Address.fromP2SHHash(params, addressHash);
 	}
-        
-        
-	
+
 	public long getLockTime() {
 		return lockTime;
 	}
-	
+
 	public TimeLockedAddressEntity setLockTime(long lockTime) {
 		this.lockTime = lockTime;
 		return this;
 	}
-	
+
 	public String toString(NetworkParameters params) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(getClass().getSimpleName());
@@ -133,51 +127,47 @@ public class TimeLockedAddressEntity {
 		sb.append("]");
 		return sb.toString();
 	}
-	
+
 	@Override
 	public String toString() {
 		return toString(null);
 	}
-	
-	@Override 
+
+	@Override
 	public boolean equals(Object object) {
 		if (object == null) {
 			return false;
 		}
-		
+
 		if (object == this) {
 			return true;
 		}
-		
+
 		if (!(object instanceof TimeLockedAddressEntity)) {
 			return false;
 		}
-		
+
 		final TimeLockedAddressEntity other = (TimeLockedAddressEntity) object;
-		return new EqualsBuilder()
-				.append(id, other.getId())
-				.append(addressHash, other.getAddressHash())
-				.append(redeemScript, other.getRedeemScript())
-				.isEquals();
+		return new EqualsBuilder().append(id, other.getId())
+			.append(addressHash, other.getAddressHash())
+			.append(redeemScript, other.getRedeemScript())
+			.isEquals();
 	}
-	
+
 	@Override
 	public int hashCode() {
-	     return new HashCodeBuilder()
-	    		 .append(id)
-	    		 .append(addressHash)
-	    		 .append(redeemScript)
-	    		 .toHashCode();
+		return new HashCodeBuilder().append(id).append(addressHash).append(redeemScript).toHashCode();
 	}
-	
+
 	/**
-	 * Sorts addresses by {@link TimeLockedAddressEntity#timeCreated} in ascending order.
+	 * Sorts addresses by {@link TimeLockedAddressEntity#timeCreated} in
+	 * ascending order.
 	 */
 	public static class TimeCreatedComparator implements Comparator<TimeLockedAddressEntity> {
 		@Override
 		public int compare(TimeLockedAddressEntity lhs, TimeLockedAddressEntity rhs) {
 			return Long.compare(lhs.getTimeCreated(), rhs.getTimeCreated());
 		}
-		
+
 	}
 }

--- a/src/main/java/com/coinblesk/server/entity/Tx.java
+++ b/src/main/java/com/coinblesk/server/entity/Tx.java
@@ -16,9 +16,17 @@
 
 package com.coinblesk.server.entity;
 
-import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 /**
  *
@@ -27,70 +35,70 @@ import java.util.Date;
  */
 
 @Entity(name = "TX")
-@Table(indexes = {@Index(name = "TX_CLIENT_PUBLIC_KEY", columnList = "CLIENT_PUBLIC_KEY")})
+@Table(indexes = { @Index(name = "TX_CLIENT_PUBLIC_KEY", columnList = "CLIENT_PUBLIC_KEY") })
 public class Tx implements Serializable {
-    private static final long serialVersionUID = -7496348013847426945L;
+	private static final long serialVersionUID = -7496348013847426945L;
 
-    @Id
-    @Column(name = "TX_HASH", updatable = false, length = 255)
-    private byte[] txHash;
+	@Id
+	@Column(name = "TX_HASH", updatable = false, length = 255)
+	private byte[] txHash;
 
-    @Column(name = "CLIENT_PUBLIC_KEY", nullable = false, updatable = false, length = 255)
-    private byte[] clientPublicKey;
+	@Column(name = "CLIENT_PUBLIC_KEY", nullable = false, updatable = false, length = 255)
+	private byte[] clientPublicKey;
 
-    @Lob
-    @Column(name = "TX", nullable = false, updatable = false)
-    private byte[] tx;
+	@Lob
+	@Column(name = "TX", nullable = false, updatable = false)
+	private byte[] tx;
 
-    @Column(name = "APPROVED", nullable = false)
-    private boolean approved;
-    
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "CREATION_DATE", nullable = false)
-    private Date creationDate;
+	@Column(name = "APPROVED", nullable = false)
+	private boolean approved;
 
-    public byte[] txHash() {
-        return txHash;
-    }
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "CREATION_DATE", nullable = false)
+	private Date creationDate;
 
-    public Tx txHash(byte[] txHash) {
-        this.txHash = txHash;
-        return this;
-    }
+	public byte[] txHash() {
+		return txHash;
+	}
 
-    public byte[] clientPublicKey() {
-        return clientPublicKey;
-    }
+	public Tx txHash(byte[] txHash) {
+		this.txHash = txHash;
+		return this;
+	}
 
-    public Tx clientPublicKey(byte[] clientPublicKey) {
-        this.clientPublicKey = clientPublicKey;
-        return this;
-    }
+	public byte[] clientPublicKey() {
+		return clientPublicKey;
+	}
 
-    public byte[] tx() {
-        return tx;
-    }
+	public Tx clientPublicKey(byte[] clientPublicKey) {
+		this.clientPublicKey = clientPublicKey;
+		return this;
+	}
 
-    public Tx tx(byte[] tx) {
-        this.tx = tx;
-        return this;
-    }
-    
-    public boolean approved() {
-        return approved;
-    }
+	public byte[] tx() {
+		return tx;
+	}
 
-    public Tx approved(boolean approved) {
-        this.approved = approved;
-        return this;
-    }
+	public Tx tx(byte[] tx) {
+		this.tx = tx;
+		return this;
+	}
 
-    public Date creationDate() {
-        return creationDate;
-    }
+	public boolean approved() {
+		return approved;
+	}
 
-    public Tx creationDate(Date creationDate) {
-        this.creationDate = creationDate;
-        return this;
-    }
+	public Tx approved(boolean approved) {
+		this.approved = approved;
+		return this;
+	}
+
+	public Date creationDate() {
+		return creationDate;
+	}
+
+	public Tx creationDate(Date creationDate) {
+		this.creationDate = creationDate;
+		return this;
+	}
 }

--- a/src/main/java/com/coinblesk/server/entity/TxQueue.java
+++ b/src/main/java/com/coinblesk/server/entity/TxQueue.java
@@ -16,9 +16,15 @@
 
 package com.coinblesk.server.entity;
 
-import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 /**
  *
@@ -28,44 +34,44 @@ import java.util.Date;
 
 @Entity(name = "TX_QUEUE")
 public class TxQueue implements Serializable {
-    private static final long serialVersionUID = -7496348013847426945L;
+	private static final long serialVersionUID = -7496348013847426945L;
 
-    @Id
-    @Column(name = "TX_HASH", updatable = false, length = 255)
-    private byte[] txHash;
+	@Id
+	@Column(name = "TX_HASH", updatable = false, length = 255)
+	private byte[] txHash;
 
-    @Lob
-    @Column(name = "TX", nullable = false, updatable = false)
-    private byte[] tx;
-    
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "CREATION_DATE", nullable = false)
-    private Date creationDate;
+	@Lob
+	@Column(name = "TX", nullable = false, updatable = false)
+	private byte[] tx;
 
-    public byte[] txHash() {
-        return txHash;
-    }
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "CREATION_DATE", nullable = false)
+	private Date creationDate;
 
-    public TxQueue txHash(byte[] txHash) {
-        this.txHash = txHash;
-        return this;
-    }
+	public byte[] txHash() {
+		return txHash;
+	}
 
-    public byte[] tx() {
-        return tx;
-    }
+	public TxQueue txHash(byte[] txHash) {
+		this.txHash = txHash;
+		return this;
+	}
 
-    public TxQueue tx(byte[] tx) {
-        this.tx = tx;
-        return this;
-    }
+	public byte[] tx() {
+		return tx;
+	}
 
-    public Date creationDate() {
-        return creationDate;
-    }
+	public TxQueue tx(byte[] tx) {
+		this.tx = tx;
+		return this;
+	}
 
-    public TxQueue creationDate(Date creationDate) {
-        this.creationDate = creationDate;
-        return this;
-    }
+	public Date creationDate() {
+		return creationDate;
+	}
+
+	public TxQueue creationDate(Date creationDate) {
+		this.creationDate = creationDate;
+		return this;
+	}
 }

--- a/src/main/java/com/coinblesk/server/entity/UserAccount.java
+++ b/src/main/java/com/coinblesk/server/entity/UserAccount.java
@@ -16,10 +16,10 @@
 
 package com.coinblesk.server.entity;
 
-import com.coinblesk.server.config.UserRole;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Date;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -32,168 +32,168 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
+import com.coinblesk.server.config.UserRole;
 
 /**
  *
  * @author Thomas Bocek
  */
 @Entity(name = "USER_ACCOUNT")
-@Table(indexes = {
-    @Index(name = "USERNAME_INDEX", columnList = "USERNAME")})
+@Table(indexes = { @Index(name = "USERNAME_INDEX", columnList = "USERNAME") })
 public class UserAccount implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "ID", nullable = false)
-    private long id;
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "CREATION_DATE", nullable = false)
-    private Date creationDate;
-    @Column(name = "USERNAME", nullable = true)
-    private String username;
-    @Column(name = "EMAIL", unique = true, nullable = false)
-    private String email;
-    @Column(name = "PASSWORD", nullable = false)
-    private String password;
-    @Column(name = "DELETED", nullable = false)
-    private boolean deleted;
-    @Column(name = "BALANCE", nullable = true, precision = 25, scale = 8)
-    private BigDecimal balance;
-    @Column(name = "EMAIL_TOKEN", nullable = true)
-    private String emailToken;
-    @Column(name = "FORGOT_PASSWORD", nullable = true)
-    private String forgotPassword;
-    @Column(name = "FORGOT_EMAIL_TOKEN", nullable = true)
-    private String forgotEmailToken;
-    
-    @Enumerated(EnumType.STRING)
-    @Column(name="USER_ROLE")
-    private UserRole userRole;
-    
-    public boolean isDeleted() {
-        return deleted;
-    }
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "ID", nullable = false)
+	private long id;
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "CREATION_DATE", nullable = false)
+	private Date creationDate;
+	@Column(name = "USERNAME", nullable = true)
+	private String username;
+	@Column(name = "EMAIL", unique = true, nullable = false)
+	private String email;
+	@Column(name = "PASSWORD", nullable = false)
+	private String password;
+	@Column(name = "DELETED", nullable = false)
+	private boolean deleted;
+	@Column(name = "BALANCE", nullable = true, precision = 25, scale = 8)
+	private BigDecimal balance;
+	@Column(name = "EMAIL_TOKEN", nullable = true)
+	private String emailToken;
+	@Column(name = "FORGOT_PASSWORD", nullable = true)
+	private String forgotPassword;
+	@Column(name = "FORGOT_EMAIL_TOKEN", nullable = true)
+	private String forgotEmailToken;
 
-    public UserAccount setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
+	@Enumerated(EnumType.STRING)
+	@Column(name = "USER_ROLE")
+	private UserRole userRole;
 
-    public long getId() {
-        return id;
-    }
+	public boolean isDeleted() {
+		return deleted;
+	}
 
-    public UserAccount setId(long id) {
-        this.id = id;
-        return this;
-    }
+	public UserAccount setDeleted(boolean deleted) {
+		this.deleted = deleted;
+		return this;
+	}
 
-    public String getUsername() {
-        return username;
-    }
+	public long getId() {
+		return id;
+	}
 
-    public UserAccount setUsername(String username) {
-        this.username = username;
-        return this;
-    }
+	public UserAccount setId(long id) {
+		this.id = id;
+		return this;
+	}
 
-    public String getEmail() {
-        return email;
-    }
+	public String getUsername() {
+		return username;
+	}
 
-    public UserAccount setEmail(String email) {
-        this.email = email;
-        return this;
-    }
+	public UserAccount setUsername(String username) {
+		this.username = username;
+		return this;
+	}
 
-    public String getPassword() {
-        return password;
-    }
+	public String getEmail() {
+		return email;
+	}
 
-    public UserAccount setPassword(String password) {
-        this.password = password;
-        return this;
-    }
+	public UserAccount setEmail(String email) {
+		this.email = email;
+		return this;
+	}
 
-    public BigDecimal getBalance() {
-        return balance;
-    }
+	public String getPassword() {
+		return password;
+	}
 
-    public UserAccount setBalance(BigDecimal balance) {
-        this.balance = balance;
-        return this;
-    }
+	public UserAccount setPassword(String password) {
+		this.password = password;
+		return this;
+	}
 
-    public Date getCreationDate() {
-        return creationDate;
-    }
+	public BigDecimal getBalance() {
+		return balance;
+	}
 
-    public UserAccount setCreationDate(Date creationDate) {
-        this.creationDate = creationDate;
-        return this;
-    }
+	public UserAccount setBalance(BigDecimal balance) {
+		this.balance = balance;
+		return this;
+	}
 
-    public String getEmailToken() {
-        return emailToken;
-    }
+	public Date getCreationDate() {
+		return creationDate;
+	}
 
-    public UserAccount setEmailToken(String emailToken) {
-        this.emailToken = emailToken;
-        return this;
-    }
-    
-    public String getForgotPassword() {
-        return forgotPassword;
-    }
+	public UserAccount setCreationDate(Date creationDate) {
+		this.creationDate = creationDate;
+		return this;
+	}
 
-    public UserAccount setForgotPassword(String forgotPassword) {
-        this.forgotPassword = forgotPassword;
-        return this;
-    }
-    
-    public String getForgotEmailToken() {
-        return forgotEmailToken;
-    }
+	public String getEmailToken() {
+		return emailToken;
+	}
 
-    public UserAccount setForgotEmailToken(String forgotEmailToken) {
-        this.forgotEmailToken = forgotEmailToken;
-        return this;
-    }
-    
-    public UserRole getUserRole() {
-    	return userRole;
-    }
-    
-    public UserAccount setUserRole(UserRole userRole) {
-    	this.userRole = userRole;
-    	return this;
-    }
+	public UserAccount setEmailToken(String emailToken) {
+		this.emailToken = emailToken;
+		return this;
+	}
 
-    public boolean isEmailVerified() {
-        return this.emailToken == null;
-    }
-    
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder()
-            .append("id: ")
-            .append(getId())
-            .append(", username: ")
-            .append(getUsername())
-            .append(", email: ")
-            .append(getEmail())
-            .append(", isDeleted: ")
-            .append(isDeleted())
-            .append(", creationDate: ")
-            .append(getCreationDate())
-            .append(", balance: ")
-            .append(getBalance())
-            .append(", emailToken: ")
-            .append(getEmailToken())
-            .append(", userRoles: ")
-            .append(getUserRole());
-        return sb.toString();
-    }
+	public String getForgotPassword() {
+		return forgotPassword;
+	}
+
+	public UserAccount setForgotPassword(String forgotPassword) {
+		this.forgotPassword = forgotPassword;
+		return this;
+	}
+
+	public String getForgotEmailToken() {
+		return forgotEmailToken;
+	}
+
+	public UserAccount setForgotEmailToken(String forgotEmailToken) {
+		this.forgotEmailToken = forgotEmailToken;
+		return this;
+	}
+
+	public UserRole getUserRole() {
+		return userRole;
+	}
+
+	public UserAccount setUserRole(UserRole userRole) {
+		this.userRole = userRole;
+		return this;
+	}
+
+	public boolean isEmailVerified() {
+		return this.emailToken == null;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder()
+				.append("id: ")
+				.append(getId())
+				.append(", username: ")
+				.append(getUsername())
+				.append(", email: ")
+				.append(getEmail())
+				.append(", isDeleted: ")
+				.append(isDeleted())
+				.append(", creationDate: ")
+				.append(getCreationDate())
+				.append(", balance: ")
+				.append(getBalance())
+				.append(", emailToken: ")
+				.append(getEmailToken())
+				.append(", userRoles: ")
+				.append(getUserRole());
+		return sb.toString();
+	}
 }

--- a/src/main/java/com/coinblesk/server/service/ForexService.java
+++ b/src/main/java/com/coinblesk/server/service/ForexService.java
@@ -21,6 +21,11 @@ import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,15 +36,10 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 /**
  *
- * Service that provides bitcoin and forex exchange rates. This class also caches exchange rates.
+ * Service that provides bitcoin and forex exchange rates. This class also
+ * caches exchange rates.
  *
  * @author rvoellmy
  * @author Thomas Bocek
@@ -48,101 +48,111 @@ import java.util.Set;
 @Service
 final public class ForexService {
 
-    //18min
-    public final static int CACHING_TIME_RATE_MILLIS = 18 * 60 * 1000;
-    //2 days
-    public final static int CACHING_TIME_SYMBOL_MILLIS = 2 * 24 * 60 * 60 * 1000;
+	// 18min
+	public final static int CACHING_TIME_RATE_MILLIS = 18 * 60 * 1000;
+	// 2 days
+	public final static int CACHING_TIME_SYMBOL_MILLIS = 2 * 24 * 60 * 60 * 1000;
 
-    private final static String USER_AGENT = "Mozilla/5.0";
-    private final static String PLACEHOLDER = "{{PLACEHOLDER}}";
-    private final static String YAHOO_API = "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20yahoo.finance.xchange%20where%20pair%20in%20("
-            + PLACEHOLDER + ")&format=json&env=store://datatables.org/alltableswithkeys";
+	private final static String USER_AGENT = "Mozilla/5.0";
+	private final static String PLACEHOLDER = "{{PLACEHOLDER}}";
+	private final static String YAHOO_API = "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20yahoo.finance.xchange%20where%20pair%20in%20("
+			+ PLACEHOLDER
+			+ ")&format=json&env=store://datatables.org/alltableswithkeys";
 
-    private final Cache<String, BigDecimal> exchangeRatesCache = CacheBuilder.newBuilder().
-            expireAfterWrite(CACHING_TIME_RATE_MILLIS, TimeUnit.MILLISECONDS).build();
+	private final Cache<String, BigDecimal> exchangeRatesCache = CacheBuilder
+			.newBuilder()
+			.expireAfterWrite(
+				CACHING_TIME_RATE_MILLIS,
+				TimeUnit.MILLISECONDS)
+			.build();
 
-    private final Cache<String, Boolean> exchangeRatesSymbolCache = CacheBuilder.newBuilder().
-            expireAfterWrite(CACHING_TIME_SYMBOL_MILLIS, TimeUnit.MILLISECONDS).build();
+	private final Cache<String, Boolean> exchangeRatesSymbolCache = CacheBuilder.newBuilder()
+			.expireAfterWrite(
+				CACHING_TIME_SYMBOL_MILLIS,
+				TimeUnit.MILLISECONDS)
+			.build();
 
-    /**
-     * Returns the exchange rate of 1 USD against the specified currency (by default CHF)
-     *
-     * @return the forex exchange rate
-     * @throws Exception
-     */
-    public BigDecimal getExchangeRate(final String symbolFrom, final String symbolTo) throws Exception {
-        final String pair = symbolFrom + symbolTo;
-        return getExchangeRates(pair).get(pair);
-    }
+	/**
+	 * Returns the exchange rate of 1 USD against the specified currency (by
+	 * default CHF)
+	 *
+	 * @return the forex exchange rate
+	 * @throws Exception
+	 */
+	public BigDecimal getExchangeRate(final String symbolFrom, final String symbolTo) throws Exception {
+		final String pair = symbolFrom + symbolTo;
+		return getExchangeRates(pair).get(pair);
+	}
 
-    public Map<String, BigDecimal> getExchangeRates(final String... pairs) throws Exception {
-        //mark as used
-        Map<String, BigDecimal> exchangeRates = new HashMap<>(pairs.length);
-        List<String> unknowRates = new ArrayList<>(1); //this empty most of the times
-        for (String pair : pairs) {
-            exchangeRatesSymbolCache.put(pair, Boolean.TRUE);
-            BigDecimal exchangeRate = exchangeRatesCache.getIfPresent(pair);
+	public Map<String, BigDecimal> getExchangeRates(final String... pairs) throws Exception {
+		// mark as used
+		Map<String, BigDecimal> exchangeRates = new HashMap<>(pairs.length);
+		// this empty most of the times:
+		List<String> unknowRates = new ArrayList<>(1); 
+		for (String pair : pairs) {
+			exchangeRatesSymbolCache.put(pair, Boolean.TRUE);
+			BigDecimal exchangeRate = exchangeRatesCache.getIfPresent(pair);
 
-            if (exchangeRate == null) {
-                unknowRates.add(pair);
-            } else {
-                exchangeRates.put(pair, exchangeRate);
-            }
-        }
+			if (exchangeRate == null) {
+				unknowRates.add(pair);
+			} else {
+				exchangeRates.put(pair, exchangeRate);
+			}
+		}
 
-        if (!unknowRates.isEmpty()) {
-            String values = String.join("\",\"", unknowRates);
-            String rates = '"' + values + '"';
-            final String url = YAHOO_API.replace(PLACEHOLDER, rates);
-            final StringBuffer response = doHttpRequest(url);
-            // gets actual exchange rate out of Json Object and saves it to last.
-            final Gson gson = new Gson();
-            if(unknowRates.size() > 1) {
-                final RootMulti root = gson.fromJson(response.toString(), RootMulti.class);
-                for (RootMulti.Query.Results.Rate rate : root.query.results.rate) {
-                    BigDecimal exchangeRate = new BigDecimal(rate.Rate);
-                    exchangeRatesCache.put(rate.id, exchangeRate);
-                    exchangeRates.put(rate.id, exchangeRate);
-                }
-            } else {
-                final RootSingle root = gson.fromJson(response.toString(), RootSingle.class);
-                BigDecimal exchangeRate = new BigDecimal(root.query.results.rate.Rate);
-                exchangeRatesCache.put(root.query.results.rate.id, exchangeRate);
-                exchangeRates.put(root.query.results.rate.id, exchangeRate);
-            }
-        }
+		if (!unknowRates.isEmpty()) {
+			String values = String.join("\",\"", unknowRates);
+			String rates = '"' + values + '"';
+			final String url = YAHOO_API.replace(PLACEHOLDER, rates);
+			final StringBuffer response = doHttpRequest(url);
+			// gets actual exchange rate out of Json Object and saves it to last.
+			final Gson gson = new Gson();
+			if (unknowRates.size() > 1) {
+				final RootMulti root = gson.fromJson(response.toString(), RootMulti.class);
+				for (RootMulti.Query.Results.Rate rate : root.query.results.rate) {
+					BigDecimal exchangeRate = new BigDecimal(rate.Rate);
+					exchangeRatesCache.put(rate.id, exchangeRate);
+					exchangeRates.put(rate.id, exchangeRate);
+				}
+			} else {
+				final RootSingle root = gson.fromJson(response.toString(), RootSingle.class);
+				BigDecimal exchangeRate = new BigDecimal(root.query.results.rate.Rate);
+				exchangeRatesCache.put(root.query.results.rate.id, exchangeRate);
+				exchangeRates.put(root.query.results.rate.id, exchangeRate);
+			}
+		}
 
-        return exchangeRates;
-    }
+		return exchangeRates;
+	}
 
-    /**
-     * Executes JSON HTTP Request and returns result.
-     *
-     * @param url
-     * @return response of defined by url request
-     * @throws IOException
-     */
-    private static StringBuffer doHttpRequest(String url) throws IOException {
-        final URL requestURL = new URL(url);
-        final HttpURLConnection con = (HttpURLConnection) requestURL.openConnection();
+	/**
+	 * Executes JSON HTTP Request and returns result.
+	 *
+	 * @param url
+	 * @return response of defined by url request
+	 * @throws IOException
+	 */
+	private static StringBuffer doHttpRequest(String url) throws IOException {
+		final URL requestURL = new URL(url);
+		final HttpURLConnection con = (HttpURLConnection) requestURL.openConnection();
 
-        // optional default is GET
-        con.setRequestMethod("GET");
+		// optional default is GET
+		con.setRequestMethod("GET");
 
-        // add request header
-        con.setRequestProperty("User-Agent", USER_AGENT);
+		// add request header
+		con.setRequestProperty("User-Agent", USER_AGENT);
 
-        final StringBuffer response = new StringBuffer();
-        try (final BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
-            String inputLine;
-            while ((inputLine = in.readLine()) != null) {
-                response.append(inputLine);
-            }
-        }
-        return response;
-    }
+		final StringBuffer response = new StringBuffer();
+		try (final BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+			String inputLine;
+			while ((inputLine = in.readLine()) != null) {
+				response.append(inputLine);
+			}
+		}
+		return response;
+	}
 
-    /*-
+	/*-
 	 * minimized JSON representation. Query result looks like:
 	 *	{
 	 *	   "query":{
@@ -162,46 +172,52 @@ final public class ForexService {
 	 *	      }
 	 *	   }
 	 *	}
-	 *	</code> 
-     */
-    private static class RootSingle {
-        private Query query;
-        private static class Query {
-            private Results results;
-            private static class Results {
-                private Rate rate;
-                private static class Rate {
-                    private String Rate;
-                    private String id;
-                }
-            }
-        }
-    }
-    
-    private static class RootMulti {
-        private Query query;
-        private static class Query {
-            private Results results;
-            private static class Results {
-                private List<Rate> rate = new ArrayList<>();
-                private static class Rate {
-                    private String Rate;
-                    private String id;
-                }
-            }
-        }
-    }
+	 *	</code>
+	 */
+	private static class RootSingle {
+		private Query query;
 
-    final static public class ForexTask {
+		private static class Query {
+			private Results results;
 
-        @Autowired
-        private ForexService service;
+			private static class Results {
+				private Rate rate;
 
-        //call every 6 minutes
-        @Scheduled(fixedRate = ForexService.CACHING_TIME_RATE_MILLIS / 3)
-        public void doTask() throws Exception {
-            Set<String> set = service.exchangeRatesSymbolCache.asMap().keySet();
-            service.getExchangeRates(set.toArray(new String[set.size()]));
-        }
-    }
+				private static class Rate {
+					private String Rate;
+					private String id;
+				}
+			}
+		}
+	}
+
+	private static class RootMulti {
+		private Query query;
+
+		private static class Query {
+			private Results results;
+
+			private static class Results {
+				private List<Rate> rate = new ArrayList<>();
+
+				private static class Rate {
+					private String Rate;
+					private String id;
+				}
+			}
+		}
+	}
+
+	final static public class ForexTask {
+
+		@Autowired
+		private ForexService service;
+
+		// call every 6 minutes
+		@Scheduled(fixedRate = ForexService.CACHING_TIME_RATE_MILLIS / 3)
+		public void doTask() throws Exception {
+			Set<String> set = service.exchangeRatesSymbolCache.asMap().keySet();
+			service.getExchangeRates(set.toArray(new String[set.size()]));
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/service/KeyService.java
+++ b/src/main/java/com/coinblesk/server/service/KeyService.java
@@ -16,21 +16,22 @@
 
 package com.coinblesk.server.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Utils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.coinblesk.bitcoin.TimeLockedAddress;
 import com.coinblesk.server.dao.KeyRepository;
 import com.coinblesk.server.dao.TimeLockedAddressRepository;
 import com.coinblesk.server.entity.Keys;
 import com.coinblesk.server.entity.TimeLockedAddressEntity;
 import com.coinblesk.util.Pair;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.bitcoinj.core.ECKey;
-import org.bitcoinj.core.Utils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  *
@@ -40,91 +41,90 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class KeyService {
 
-    @Autowired
-    private KeyRepository keyRepository;
-    
-    @Autowired
-    private TimeLockedAddressRepository timeLockedAddressRepository;
-    
-    @Transactional(readOnly = true)
-    public Keys getByClientPublicKey(final byte[] clientPublicKey) {
-        return keyRepository.findByClientPublicKey(clientPublicKey);
-    }
+	@Autowired
+	private KeyRepository keyRepository;
 
-    @Transactional(readOnly = true)
-    public List<ECKey> getPublicECKeysByClientPublicKey(final byte[] clientPublicKey) {
-        final Keys keys = keyRepository.findByClientPublicKey(clientPublicKey);
-        final List<ECKey> retVal = new ArrayList<>(2);
-        retVal.add(ECKey.fromPublicOnly(keys.clientPublicKey()));
-        retVal.add(ECKey.fromPublicOnly(keys.serverPublicKey()));
-        return retVal;
-    }
-    
-    @Transactional(readOnly = true)
-    public List<ECKey> getECKeysByClientPublicKey(final byte[] clientPublicKey) {
-        final Keys keys = keyRepository.findByClientPublicKey(clientPublicKey);
-        if(keys == null) {
-            return Collections.emptyList();
-        }
-        final List<ECKey> retVal = new ArrayList<>(2);
-        retVal.add(ECKey.fromPublicOnly(keys.clientPublicKey()));
-        retVal.add(ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(), keys.serverPublicKey()));
-        return retVal;
-    }
+	@Autowired
+	private TimeLockedAddressRepository timeLockedAddressRepository;
 
-    @Transactional(readOnly = false)
-    public Pair<Boolean, Keys> storeKeysAndAddress(final byte[] clientPublicKey,
-            final byte[] serverPublicKey, final byte[] serverPrivateKey) {
-        if (clientPublicKey == null || serverPublicKey == null || serverPrivateKey == null ) {
-            throw new IllegalArgumentException("null not excpected here");
-        }
+	@Transactional(readOnly = true)
+	public Keys getByClientPublicKey(final byte[] clientPublicKey) {
+		return keyRepository.findByClientPublicKey(clientPublicKey);
+	}
 
-        //need to check if it exists here, as not all DBs do that for us
-        final Keys keys = keyRepository.findByClientPublicKey(clientPublicKey);
-        if (keys != null) {
-            return new Pair<>(false, keys);
-        }
-        
-        final Keys clientKey = new Keys()
-                .clientPublicKey(clientPublicKey)
-                .serverPrivateKey(serverPrivateKey)
-                .serverPublicKey(serverPublicKey);
+	@Transactional(readOnly = true)
+	public List<ECKey> getPublicECKeysByClientPublicKey(final byte[] clientPublicKey) {
+		final Keys keys = keyRepository.findByClientPublicKey(clientPublicKey);
+		final List<ECKey> retVal = new ArrayList<>(2);
+		retVal.add(ECKey.fromPublicOnly(keys.clientPublicKey()));
+		retVal.add(ECKey.fromPublicOnly(keys.serverPublicKey()));
+		return retVal;
+	}
 
-        final Keys storedKeys = keyRepository.save(clientKey);
-        return new Pair<>(true, storedKeys);
-    }
+	@Transactional(readOnly = true)
+	public List<ECKey> getECKeysByClientPublicKey(final byte[] clientPublicKey) {
+		final Keys keys = keyRepository.findByClientPublicKey(clientPublicKey);
+		if (keys == null) {
+			return Collections.emptyList();
+		}
+		final List<ECKey> retVal = new ArrayList<>(2);
+		retVal.add(ECKey.fromPublicOnly(keys.clientPublicKey()));
+		retVal.add(ECKey.fromPrivateAndPrecalculatedPublic(keys.serverPrivateKey(), keys.serverPublicKey()));
+		return retVal;
+	}
 
-    @Transactional(readOnly = true)
-    public List<List<ECKey>> all() {
-        final Iterable<Keys> all = keyRepository.findAll();
-        final List<List<ECKey>> retVal = new ArrayList<>();
-        for (Keys entity : all) {
-            final List<ECKey> keys = new ArrayList<>(2);
-            keys.add(ECKey.fromPublicOnly(entity.clientPublicKey()));
-            keys.add(ECKey.fromPublicOnly(entity.serverPublicKey()));
-            retVal.add(keys);
-        }
-        return retVal;
-    }
-    
-    @Transactional(readOnly = true)
-    public Iterable<Keys> allKeys() {
-    	return keyRepository.findAll();
-    }
-    
-    @Transactional(readOnly = false)
+	@Transactional(readOnly = false)
+	public Pair<Boolean, Keys> storeKeysAndAddress(final byte[] clientPublicKey, final byte[] serverPublicKey,
+			final byte[] serverPrivateKey) {
+		if (clientPublicKey == null || serverPublicKey == null || serverPrivateKey == null) {
+			throw new IllegalArgumentException("null not excpected here");
+		}
+
+		// need to check if it exists here, as not all DBs do that for us
+		final Keys keys = keyRepository.findByClientPublicKey(clientPublicKey);
+		if (keys != null) {
+			return new Pair<>(false, keys);
+		}
+
+		final Keys clientKey = new Keys()
+				.clientPublicKey(clientPublicKey)
+				.serverPrivateKey(serverPrivateKey)
+				.serverPublicKey(serverPublicKey);
+
+		final Keys storedKeys = keyRepository.save(clientKey);
+		return new Pair<>(true, storedKeys);
+	}
+
+	@Transactional(readOnly = true)
+	public List<List<ECKey>> all() {
+		final Iterable<Keys> all = keyRepository.findAll();
+		final List<List<ECKey>> retVal = new ArrayList<>();
+		for (Keys entity : all) {
+			final List<ECKey> keys = new ArrayList<>(2);
+			keys.add(ECKey.fromPublicOnly(entity.clientPublicKey()));
+			keys.add(ECKey.fromPublicOnly(entity.serverPublicKey()));
+			retVal.add(keys);
+		}
+		return retVal;
+	}
+
+	@Transactional(readOnly = true)
+	public Iterable<Keys> allKeys() {
+		return keyRepository.findAll();
+	}
+
+	@Transactional(readOnly = false)
 	public TimeLockedAddressEntity storeTimeLockedAddress(Keys keys, TimeLockedAddress address) {
 		if (address == null || keys == null) {
 			throw new IllegalArgumentException("Address/keys must not be null");
 		}
-		if (keys.serverPrivateKey() == null || keys.serverPublicKey() == null || 
-				keys.clientPublicKey() == null) {
+		if (keys.serverPrivateKey() == null || keys.serverPublicKey() == null || keys.clientPublicKey() == null) {
 			throw new IllegalArgumentException("Keys must not be null.");
 		}
 		if (address.getAddressHash() == null) {
 			throw new IllegalArgumentException("AddressHash must not be null");
 		}
-		
+
 		TimeLockedAddressEntity addressEntity = new TimeLockedAddressEntity();
 		addressEntity
 				.setLockTime(address.getLockTime())
@@ -132,38 +132,38 @@ public class KeyService {
 				.setRedeemScript(address.createRedeemScript().getProgram())
 				.setTimeCreated(Utils.currentTimeSeconds())
 				.setKeys(keys);
-		
+
 		TimeLockedAddressEntity result = timeLockedAddressRepository.save(addressEntity);
 		return result;
 	}
-    
-    public boolean addressExists(byte[] addressHash) {
-    	return timeLockedAddressRepository.findByAddressHash(addressHash) != null;
-    }
-    
-    public TimeLockedAddressEntity getTimeLockedAddressByAddressHash(byte[] addressHash) {
-    	if (addressHash == null) {
-    		throw new IllegalArgumentException("addressHash must not be null.");
-    	}
-    	return timeLockedAddressRepository.findByAddressHash(addressHash);
-    }
-    
-    public List<TimeLockedAddressEntity> getTimeLockedAddressesByClientPublicKey(byte[] publicKey) {
-    	if (publicKey == null || publicKey.length <= 0) {
-    		throw new IllegalArgumentException("publicKey must not be null");
-    	}
-    	return timeLockedAddressRepository.findByKeys_ClientPublicKey(publicKey);
-    }
 
-    public TimeLockedAddressEntity findAddressByAddressHash(byte[] addressHash) {
-    	if (addressHash == null) {
+	public boolean addressExists(byte[] addressHash) {
+		return timeLockedAddressRepository.findByAddressHash(addressHash) != null;
+	}
+
+	public TimeLockedAddressEntity getTimeLockedAddressByAddressHash(byte[] addressHash) {
+		if (addressHash == null) {
 			throw new IllegalArgumentException("addressHash must not be null.");
 		}
-    	TimeLockedAddressEntity address = timeLockedAddressRepository.findByAddressHash(addressHash);
-    	return address;
-    }
-    
-    public byte[] getRedeemScriptByAddressHash(byte[] addressHash) {
+		return timeLockedAddressRepository.findByAddressHash(addressHash);
+	}
+
+	public List<TimeLockedAddressEntity> getTimeLockedAddressesByClientPublicKey(byte[] publicKey) {
+		if (publicKey == null || publicKey.length <= 0) {
+			throw new IllegalArgumentException("publicKey must not be null");
+		}
+		return timeLockedAddressRepository.findByKeys_ClientPublicKey(publicKey);
+	}
+
+	public TimeLockedAddressEntity findAddressByAddressHash(byte[] addressHash) {
+		if (addressHash == null) {
+			throw new IllegalArgumentException("addressHash must not be null.");
+		}
+		TimeLockedAddressEntity address = timeLockedAddressRepository.findByAddressHash(addressHash);
+		return address;
+	}
+
+	public byte[] getRedeemScriptByAddressHash(byte[] addressHash) {
 		TimeLockedAddressEntity address = getTimeLockedAddressByAddressHash(addressHash);
 		byte[] data = address != null ? address.getRedeemScript() : null;
 		return data;

--- a/src/main/java/com/coinblesk/server/service/MailService.java
+++ b/src/main/java/com/coinblesk/server/service/MailService.java
@@ -1,5 +1,7 @@
 package com.coinblesk.server.service;
 
+import java.util.Properties;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,99 +12,97 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.stereotype.Service;
 
-import java.util.Properties;
-
 @Service
 public class MailService {
-    private final static Logger LOG = LoggerFactory.getLogger(MailService.class);
+	private final static Logger LOG = LoggerFactory.getLogger(MailService.class);
 
-    @Value("${email.enabled}")
-    private boolean enabled;
+	@Value("${email.enabled}")
+	private boolean enabled;
 
-    @Value("${email.host}")
-    private String host;
+	@Value("${email.host}")
+	private String host;
 
-    @Value("${email.protocol}")
-    private String protocol;
+	@Value("${email.protocol}")
+	private String protocol;
 
-    @Value("${email.port}")
-    private int port;
+	@Value("${email.port}")
+	private int port;
 
-    @Value("${email.auth}")
-    private boolean auth;
+	@Value("${email.auth}")
+	private boolean auth;
 
-    @Value("${email.starttls}")
-    private boolean starttls;
+	@Value("${email.starttls}")
+	private boolean starttls;
 
-    @Value("${email.debug}")
-    private boolean debug;
+	@Value("${email.debug}")
+	private boolean debug;
 
-    @Value("${email.trust}")
-    private String trust;
+	@Value("${email.trust}")
+	private String trust;
 
-    @Value("${email.username}")
-    private String username;
+	@Value("${email.username}")
+	private String username;
 
-    @Value("${email.password}")
-    private String password;
+	@Value("${email.password}")
+	private String password;
 
-    @Value("${email.admin}")
-    private String admin;
+	@Value("${email.admin}")
+	private String admin;
 
-    @Value("${email.sendfrom}")
-    private String sendfrom;
+	@Value("${email.sendfrom}")
+	private String sendfrom;
 
-    @Autowired
-    private JavaMailSender javaMailService;
+	@Autowired
+	private JavaMailSender javaMailService;
 
-    @Bean
-    public JavaMailSender javaMailService() {
-        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+	@Bean
+	public JavaMailSender javaMailService() {
+		JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
 
-        if(this.auth) {
-            javaMailSender.setUsername(this.username);
-            javaMailSender.setPassword(this.password);
-        }
+		if (this.auth) {
+			javaMailSender.setUsername(this.username);
+			javaMailSender.setPassword(this.password);
+		}
 
-        Properties properties = new Properties();
-        properties.setProperty("mail.transport.protocol", this.protocol);
-        properties.setProperty("mail.smtp.auth", Boolean.toString(this.auth));
-        properties.setProperty("mail.smtp.starttls.enable", Boolean.toString(this.starttls));
-        properties.setProperty("mail.debug", Boolean.toString(this.debug));
-        properties.setProperty("mail.smtp.host", this.host);
-        properties.setProperty("mail.smtp.port", Integer.toString(this.port));
-        if(this.trust != null) {
-            properties.setProperty("mail.smtp.ssl.trust", this.trust );
-        }
-        javaMailSender.setJavaMailProperties(properties);
+		Properties properties = new Properties();
+		properties.setProperty("mail.transport.protocol", this.protocol);
+		properties.setProperty("mail.smtp.auth", Boolean.toString(this.auth));
+		properties.setProperty("mail.smtp.starttls.enable", Boolean.toString(this.starttls));
+		properties.setProperty("mail.debug", Boolean.toString(this.debug));
+		properties.setProperty("mail.smtp.host", this.host);
+		properties.setProperty("mail.smtp.port", Integer.toString(this.port));
+		if (this.trust != null) {
+			properties.setProperty("mail.smtp.ssl.trust", this.trust);
+		}
+		javaMailSender.setJavaMailProperties(properties);
 
-        return javaMailSender;
-    }
+		return javaMailSender;
+	}
 
-    public void sendUserMail(String recipient, String subject, String text) {
-        sendMail(recipient, subject, text);
-    }
+	public void sendUserMail(String recipient, String subject, String text) {
+		sendMail(recipient, subject, text);
+	}
 
-    public void sendAdminMail(String subject, String text) {
-        sendMail(this.admin, subject, text);
-    }
+	public void sendAdminMail(String subject, String text) {
+		sendMail(this.admin, subject, text);
+	}
 
-    private void sendMail(String recipient, String subject, String text) {
-        if (!this.enabled) {
-            LOG.info("Skipping sending mail to {} with body: \"{}\"", recipient, text);
-            return;
-        }
+	private void sendMail(String recipient, String subject, String text) {
+		if (!this.enabled) {
+			LOG.info("Skipping sending mail to {} with body: \"{}\"", recipient, text);
+			return;
+		}
 
-        SimpleMailMessage smm = new SimpleMailMessage();
-        smm.setFrom(this.sendfrom);
-        smm.setTo(recipient);
-        smm.setSubject(subject);
-        smm.setText(text);
-        try {
-            LOG.info("send mail to {}: {}", recipient, smm);
-            javaMailService.send(smm);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+		SimpleMailMessage smm = new SimpleMailMessage();
+		smm.setFrom(this.sendfrom);
+		smm.setTo(recipient);
+		smm.setSubject(subject);
+		smm.setText(text);
+		try {
+			LOG.info("send mail to {}: {}", recipient, smm);
+			javaMailService.send(smm);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/service/TransactionService.java
+++ b/src/main/java/com/coinblesk/server/service/TransactionService.java
@@ -15,6 +15,27 @@
  */
 package com.coinblesk.server.service;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Transaction.SigHash;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.Utils;
+import org.bitcoinj.core.VerificationException;
+import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.script.Script;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.coinblesk.bitcoin.TimeLockedAddress;
 import com.coinblesk.json.v1.SignVerifyTO;
 import com.coinblesk.json.v1.TxSig;
@@ -28,27 +49,6 @@ import com.coinblesk.util.BitcoinUtils;
 import com.coinblesk.util.CoinbleskException;
 import com.coinblesk.util.SerializeUtils;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import org.bitcoinj.core.ECKey;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionInput;
-import org.bitcoinj.core.TransactionOutPoint;
-import org.bitcoinj.core.TransactionOutput;
-import org.bitcoinj.core.Utils;
-import org.bitcoinj.core.VerificationException;
-import org.bitcoinj.core.Transaction.SigHash;
-import org.bitcoinj.crypto.TransactionSignature;
-import org.bitcoinj.script.Script;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 /**
  *
  * @author Thomas Bocek
@@ -56,284 +56,277 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TransactionService {
 
-    private final static Logger LOG = LoggerFactory.getLogger(TransactionService.class);
-    private final static long LOCK_THRESHOLD_MILLIS = 1000 * 60 * 60 * 4; //4h
+	private final static Logger LOG = LoggerFactory.getLogger(TransactionService.class);
+	private final static long LOCK_THRESHOLD_MILLIS = 1000 * 60 * 60 * 4; // 4h
 
-    @Autowired
-    private AppConfig appConfig;
+	@Autowired
+	private AppConfig appConfig;
 
-    @Autowired
-    private TxRepository repository;
+	@Autowired
+	private TxRepository repository;
 
-    @Autowired
-    private WalletService walletService;
-    
-    @Autowired
-    private KeyService keyService;
-    
-    
-    @Transactional(readOnly = false)
-    public SignVerifyTO signVerifyTransaction(Transaction transaction, ECKey clientKey,
-            ECKey serverKey,
-            List<TransactionSignature> clientSigs) {
-        final String tag = "{signverify}";
-        final String clientPubKeyHex = clientKey.getPublicKeyAsHex();
-        final NetworkParameters params = appConfig.getNetworkParameters();
+	@Autowired
+	private WalletService walletService;
 
-        // Check if Tx contains already signed (spent) outputs
-        if (isBurned(params, clientKey.getPubKey(), transaction)) {
-            LOG.warn("{} - clientPubKey={} - BURNED_OUTPUTS - Transaction:\n{}", tag, clientPubKeyHex,
-                    transaction);
-            return ToUtils.newInstance(SignVerifyTO.class, Type.BURNED_OUTPUTS, serverKey);
-        }
+	@Autowired
+	private KeyService keyService;
 
-        // for each input, search corresponding redeemScript and sign
-        final List<TransactionSignature> serverSigs = new ArrayList<>(clientSigs.size());
-        Boolean instant = signTransaction(transaction, clientSigs, serverKey, serverSigs);
-        if (instant == null) {
-            LOG.warn("{} - clientPubKey={} - ALREADY_SPENT - Transaction:\n{}", tag, clientPubKeyHex,
-                    transaction);
-            return ToUtils.newInstance(SignVerifyTO.class, Type.INPUT_MISMATCH, serverKey);
-        }
+	@Transactional(readOnly = false)
+	public SignVerifyTO signVerifyTransaction(Transaction transaction, ECKey clientKey, ECKey serverKey,
+			List<TransactionSignature> clientSigs) {
+		final String tag = "{signverify}";
+		final String clientPubKeyHex = clientKey.getPublicKeyAsHex();
+		final NetworkParameters params = appConfig.getNetworkParameters();
 
-        try {
-            // verify fully signed Tx and each Tx input (execute scriptSig + redeemScript).
-            if(!verifyTransaction(transaction)) {
-                instant = false;
-            }
-        } catch (CoinbleskException e) {
-            LOG.error("{} - clientPubKey={} - Verification of transaction failed (TX_ERROR): {}", tag,
-                    clientPubKeyHex, transaction, e);
-            return ToUtils.newInstance(SignVerifyTO.class, Type.TX_ERROR, serverKey);
-        }
+		// Check if Tx contains already signed (spent) outputs
+		if (isBurned(params, clientKey.getPubKey(), transaction)) {
+			LOG.warn("{} - clientPubKey={} - BURNED_OUTPUTS - Transaction:\n{}", tag, clientPubKeyHex, transaction);
+			return ToUtils.newInstance(SignVerifyTO.class, Type.BURNED_OUTPUTS, serverKey);
+		}
 
-        // Transaction is complete: store and broadcast.
-        saveAndBroadcast(transaction, clientKey.getPubKey());
+		// for each input, search corresponding redeemScript and sign
+		final List<TransactionSignature> serverSigs = new ArrayList<>(clientSigs.size());
+		Boolean instant = signTransaction(transaction, clientSigs, serverKey, serverSigs);
+		if (instant == null) {
+			LOG.warn("{} - clientPubKey={} - ALREADY_SPENT - Transaction:\n{}", tag, clientPubKeyHex, transaction);
+			return ToUtils.newInstance(SignVerifyTO.class, Type.INPUT_MISMATCH, serverKey);
+		}
 
-        final List<TxSig> serializedServerSigs = SerializeUtils.serializeSignatures(serverSigs);
-        final SignVerifyTO responseTO = new SignVerifyTO()
-                .currentDate(System.currentTimeMillis())
-                .publicKey(serverKey.getPubKey())
-                .transaction(transaction.unsafeBitcoinSerialize())
-                .signatures(serializedServerSigs);
+		try {
+			// verify fully signed Tx and each Tx input (execute scriptSig +
+			// redeemScript).
+			if (!verifyTransaction(transaction)) {
+				instant = false;
+			}
+		} catch (CoinbleskException e) {
+			LOG.error("{} - clientPubKey={} - Verification of transaction failed (TX_ERROR): {}", tag, clientPubKeyHex,
+					transaction, e);
+			return ToUtils.newInstance(SignVerifyTO.class, Type.TX_ERROR, serverKey);
+		}
 
-        // Determine instant or not.
-        if (instant && isTransactionInstant(params, clientKey.getPubKey(), transaction)) {
-            responseTO.type(Type.SUCCESS_INSTANT);
-        } else {
-            responseTO.type(Type.SUCCESS_BUT_NO_INSTANT_PAYMENT);
-        }
+		// Transaction is complete: store and broadcast.
+		saveAndBroadcast(transaction, clientKey.getPubKey());
 
-        LOG.info("{} - clientPubKey={} - signed tx={} ({} bytes) - done with status={}",
-                tag, clientPubKeyHex, transaction.getHashAsString(), transaction.getMessageSize(), responseTO
-                .type());
-        return responseTO;
-    }
-    
-    private Boolean signTransaction(final Transaction transaction,
-            final List<TransactionSignature> clientSigs,
-            final ECKey serverKey,
-            final List<TransactionSignature> serverSigs) {
+		final List<TxSig> serializedServerSigs = SerializeUtils.serializeSignatures(serverSigs);
+		final SignVerifyTO responseTO = new SignVerifyTO()
+				.currentDate(System.currentTimeMillis())
+				.publicKey(serverKey.getPubKey())
+				.transaction(transaction.unsafeBitcoinSerialize())
+				.signatures(serializedServerSigs);
 
-        int instantCounter = 0;
+		// Determine instant or not.
+		if (instant && isTransactionInstant(params, clientKey.getPubKey(), transaction)) {
+			responseTO.type(Type.SUCCESS_INSTANT);
+		} else {
+			responseTO.type(Type.SUCCESS_BUT_NO_INSTANT_PAYMENT);
+		}
 
-        for (int inputIndex = 0; inputIndex < transaction.getInputs().size(); ++inputIndex) {
-            TransactionInput txIn = transaction.getInput(inputIndex);
-            // get output from wallet because Tx may not be connected if received over the network.
-            TransactionOutput txOut = walletService.findOutputFor(txIn);
-            final byte[] redeemScript;
-            if (txOut != null) {
-                byte[] addressHashFrom = txOut.getScriptPubKey().getPubKeyHash();
-                redeemScript = keyService.getRedeemScriptByAddressHash(addressHashFrom);
-                if (redeemScript == null) {
-                    instantCounter++;
-                    LOG
-                            .warn("signTransaction - redeem script for input {} not found - output: {}",
-                                    inputIndex, txOut);
-                    continue;
-                }
-                // Check if outputs are spendable
-                if (!txOut.isAvailableForSpending()) {
-                    return null;
-                }
-
-            } else {
-                instantCounter++;
-                // may happen if Tx contains inputs of other transactions
-                // not related to coinblesk (unknown tx outputs).
-                LOG.warn("signTransaction - transaction output for tx input {} not found - input: {}",
-                        inputIndex, txIn);
-                redeemScript = null;
-                continue;
-            }
-
-            TransactionSignature clientSig = clientSigs.get(inputIndex);
-            TransactionSignature serverSig = transaction.calculateSignature(
-                    inputIndex, serverKey, redeemScript, SigHash.ALL, false);
-            serverSigs.add(serverSig);
-
-            TimeLockedAddress tla = TimeLockedAddress.fromRedeemScript(redeemScript);
-            Script scriptSig = tla.createScriptSigBeforeLockTime(clientSig, serverSig);
-            txIn.setScriptSig(scriptSig);
-        }
-        return instantCounter == 0;
-    }
-    
-    private void saveAndBroadcast(Transaction transaction, byte[] clientPubKey) {
-    	final byte[] serializedTx = transaction.unsafeBitcoinSerialize();
-        addTransaction(clientPubKey, serializedTx, transaction.getHash().getBytes(), false);
-        walletService.receivePending(transaction);
-    	walletService.broadcast(transaction);
+		LOG.info("{} - clientPubKey={} - signed tx={} ({} bytes) - done with status={}", tag, clientPubKeyHex,
+				transaction.getHashAsString(), transaction.getMessageSize(), responseTO.type());
+		return responseTO;
 	}
-    
-    /**
-     *  Transaction verification
-     *  Note: this is the verification of the Bitcoin rules (scripts and signatures), 
-     *  not the instant payment rules.
-     *  
-     * @param transaction
-     * @throws CoinbleskException if verification fails
-     */		 
-    private boolean verifyTransaction(Transaction transaction) throws CoinbleskException {
-        int counter = 0;
-        try {
-            transaction.verify();
-            for (TransactionInput txIn : transaction.getInputs()) {
-                TransactionOutput txOut = walletService.findOutputFor(txIn);
-                if(txOut == null) {
-                    counter++;
-                }
-                txIn.verify(txOut);
-            }
-        } catch (VerificationException e) {
-            throw new CoinbleskException("Verification of transaction failed", e);
-        }
-        return counter == 0;
-    }
 
-    @Transactional(readOnly = false)
-    public boolean isTransactionInstant(final NetworkParameters params, byte[] clientPublicKey, Transaction fullTx) {
-        //check if the funding (inputs) of fullTx are timelocked
-        return isTransactionInstant(params, clientPublicKey, fullTx, null);
-    }
+	private Boolean signTransaction(final Transaction transaction, final List<TransactionSignature> clientSigs,
+			final ECKey serverKey, final List<TransactionSignature> serverSigs) {
 
-    private boolean isTransactionInstant(final NetworkParameters params, final byte[] clientPublicKey, 
-																		 final Transaction fullTx,
-        																 final Transaction requester) {
-        // fullTx can be null, we did not find a parent!
-        if (fullTx == null) {
-            LOG.debug("(instant-check) we did not find a parent transaction for tx={}", requester);
-            return false;
-        }
+		int instantCounter = 0;
 
-        // check if already approved
-        List<Transaction> approved = listTransactions(params, clientPublicKey, true);
-        for (Transaction tx : approved) {
-            if (tx.getHash().equals(fullTx.getHash())) {
-                LOG.debug("(instant-check) already approved tx={}", tx.getHash());
-                return true;
-            }
-        }
-        // if we have a tx that is confirmed, we are good to go
-        if (fullTx.getConfidence().getDepthInBlocks() >= appConfig.getMinConf()) {
-            LOG.debug("(instant-check) the confidence is good: confirmations={}, tx={}", 
-            		fullTx.getConfidence().getDepthInBlocks(), fullTx.getHashAsString());
-            return true;
-        }
-        
-        final List<TransactionInput> inputsToCheck = fullTx.getInputs();
-        final List<Transaction> clientTransactions = listTransactions(params, clientPublicKey, false);
+		for (int inputIndex = 0; inputIndex < transaction.getInputs().size(); ++inputIndex) {
+			TransactionInput txIn = transaction.getInput(inputIndex);
+			// get output from wallet because Tx may not be connected if
+			// received over the network.
+			TransactionOutput txOut = walletService.findOutputFor(txIn);
+			final byte[] redeemScript;
+			if (txOut != null) {
+				byte[] addressHashFrom = txOut.getScriptPubKey().getPubKeyHash();
+				redeemScript = keyService.getRedeemScriptByAddressHash(addressHashFrom);
+				if (redeemScript == null) {
+					instantCounter++;
+					LOG.warn("signTransaction - redeem script for input {} not found - output: {}", inputIndex, txOut);
+					continue;
+				}
+				// Check if outputs are spendable
+				if (!txOut.isAvailableForSpending()) {
+					return null;
+				}
 
-        // check double signing
-        final boolean signedExactlyOnce = signedExactlyOnce(clientTransactions, inputsToCheck);
-        if (!signedExactlyOnce) {
-        	LOG.debug("(instant-check) signedExactlyOnce={}, tx={}", signedExactlyOnce, fullTx.getHashAsString());
-            return false;
-        }
-        
-        // check that the outputs are locked: either 2-of-2 multisig OR timeLocked in the future.
-        boolean inputsLocked = areInputsLocked(inputsToCheck);
-        if (!inputsLocked) {
-        	LOG.debug("(instant-check) areInputsLocked={}, tx={}", inputsLocked, fullTx.getHashAsString());
-        	return false;
-        }
+			} else {
+				instantCounter++;
+				// may happen if Tx contains inputs of other transactions
+				// not related to coinblesk (unknown tx outputs).
+				LOG.warn("signTransaction - transaction output for tx input {} not found - input: {}", inputIndex,
+						txIn);
+				redeemScript = null;
+				continue;
+			}
 
-        // check whether the parents of the inputs are instant 
-        boolean areParentsInstant = areParentsInstant(params, fullTx, clientPublicKey);
-        if (areParentsInstant) {
-        	LOG.debug("(instant-check) areParentsInstant={}, tx={}", areParentsInstant, fullTx.getHashAsString());
-            addTransaction(clientPublicKey, fullTx.unsafeBitcoinSerialize(), fullTx.getHash().getBytes(), true);
-        }
-        return areParentsInstant;
-    }
-    
-    private boolean areParentsInstant(NetworkParameters params, Transaction fullTx, byte[] clientPublicKey) {
-    	boolean areParentsInstant = false;
-        for (TransactionInput relevantTransactionInput : fullTx.getInputs()) {
-            TransactionOutput transactionOutput = walletService.findOutputFor(relevantTransactionInput);
-            //input may not be connected, it may be null
-            if (transactionOutput == null) {
-                LOG.debug("(instant-check) this input is not connected (tx={})! {}", 
-                		fullTx.getHashAsString(), relevantTransactionInput);
-                areParentsInstant = false;
-                break;
-            }
-            // continue recursion
-            final Transaction parentTransaction = transactionOutput.getParentTransaction();
-            areParentsInstant = isTransactionInstant(params, clientPublicKey, parentTransaction, fullTx);
-            if (!areParentsInstant) {
-            	break;
-            }
-        }
-        return areParentsInstant;
-    }
+			TransactionSignature clientSig = clientSigs.get(inputIndex);
+			TransactionSignature serverSig = transaction.calculateSignature(inputIndex, serverKey, redeemScript,
+					SigHash.ALL, false);
+			serverSigs.add(serverSig);
+
+			TimeLockedAddress tla = TimeLockedAddress.fromRedeemScript(redeemScript);
+			Script scriptSig = tla.createScriptSigBeforeLockTime(clientSig, serverSig);
+			txIn.setScriptSig(scriptSig);
+		}
+		return instantCounter == 0;
+	}
+
+	private void saveAndBroadcast(Transaction transaction, byte[] clientPubKey) {
+		final byte[] serializedTx = transaction.unsafeBitcoinSerialize();
+		addTransaction(clientPubKey, serializedTx, transaction.getHash().getBytes(), false);
+		walletService.receivePending(transaction);
+		walletService.broadcast(transaction);
+	}
+
+	/**
+	 * Transaction verification
+	 * Note: this is the verification of the Bitcoin rules (scripts and signatures),
+	 * not the instant payment rules.
+	 *
+	 * @param transaction
+	 * @throws CoinbleskException if verification fails
+	 */
+	private boolean verifyTransaction(Transaction transaction) throws CoinbleskException {
+		int counter = 0;
+		try {
+			transaction.verify();
+			for (TransactionInput txIn : transaction.getInputs()) {
+				TransactionOutput txOut = walletService.findOutputFor(txIn);
+				if (txOut == null) {
+					counter++;
+				}
+				txIn.verify(txOut);
+			}
+		} catch (VerificationException e) {
+			throw new CoinbleskException("Verification of transaction failed", e);
+		}
+		return counter == 0;
+	}
+
+	@Transactional(readOnly = false)
+	public boolean isTransactionInstant(final NetworkParameters params, byte[] clientPublicKey, Transaction fullTx) {
+		// check if the funding (inputs) of fullTx are timelocked
+		return isTransactionInstant(params, clientPublicKey, fullTx, null);
+	}
+
+	private boolean isTransactionInstant(final NetworkParameters params, final byte[] clientPublicKey,
+			final Transaction fullTx, final Transaction requester) {
+		// fullTx can be null, we did not find a parent!
+		if (fullTx == null) {
+			LOG.debug("(instant-check) we did not find a parent transaction for tx={}", requester);
+			return false;
+		}
+
+		// check if already approved
+		List<Transaction> approved = listTransactions(params, clientPublicKey, true);
+		for (Transaction tx : approved) {
+			if (tx.getHash().equals(fullTx.getHash())) {
+				LOG.debug("(instant-check) already approved tx={}", tx.getHash());
+				return true;
+			}
+		}
+		// if we have a tx that is confirmed, we are good to go
+		if (fullTx.getConfidence().getDepthInBlocks() >= appConfig.getMinConf()) {
+			LOG.debug("(instant-check) the confidence is good: confirmations={}, tx={}",
+					fullTx.getConfidence().getDepthInBlocks(), fullTx.getHashAsString());
+			return true;
+		}
+
+		final List<TransactionInput> inputsToCheck = fullTx.getInputs();
+		final List<Transaction> clientTransactions = listTransactions(params, clientPublicKey, false);
+
+		// check double signing
+		final boolean signedExactlyOnce = signedExactlyOnce(clientTransactions, inputsToCheck);
+		if (!signedExactlyOnce) {
+			LOG.debug("(instant-check) signedExactlyOnce={}, tx={}", signedExactlyOnce, fullTx.getHashAsString());
+			return false;
+		}
+
+		// check that the outputs are locked: either 2-of-2 multisig OR
+		// timeLocked in the future.
+		boolean inputsLocked = areInputsLocked(inputsToCheck);
+		if (!inputsLocked) {
+			LOG.debug("(instant-check) areInputsLocked={}, tx={}", inputsLocked, fullTx.getHashAsString());
+			return false;
+		}
+
+		// check whether the parents of the inputs are instant
+		boolean areParentsInstant = areParentsInstant(params, fullTx, clientPublicKey);
+		if (areParentsInstant) {
+			LOG.debug("(instant-check) areParentsInstant={}, tx={}", areParentsInstant, fullTx.getHashAsString());
+			addTransaction(clientPublicKey, fullTx.unsafeBitcoinSerialize(), fullTx.getHash().getBytes(), true);
+		}
+		return areParentsInstant;
+	}
+
+	private boolean areParentsInstant(NetworkParameters params, Transaction fullTx, byte[] clientPublicKey) {
+		boolean areParentsInstant = false;
+		for (TransactionInput relevantTransactionInput : fullTx.getInputs()) {
+			TransactionOutput transactionOutput = walletService.findOutputFor(relevantTransactionInput);
+			// input may not be connected, it may be null
+			if (transactionOutput == null) {
+				LOG.debug("(instant-check) this input is not connected (tx={})! {}", fullTx.getHashAsString(),
+						relevantTransactionInput);
+				areParentsInstant = false;
+				break;
+			}
+			// continue recursion
+			final Transaction parentTransaction = transactionOutput.getParentTransaction();
+			areParentsInstant = isTransactionInstant(params, clientPublicKey, parentTransaction, fullTx);
+			if (!areParentsInstant) {
+				break;
+			}
+		}
+		return areParentsInstant;
+	}
 
 	private boolean areInputsLocked(List<TransactionInput> inputs) {
-    	for (TransactionInput input : inputs) {
-    		TransactionOutput output = walletService.findOutputFor(input);
-    		if (output == null) {
-    			LOG.debug("Cannot determine whether output is locked or not (Tx not connected).");
-    			return false;
-    		}
-    		
-    		byte[] addressHash = output.getScriptPubKey().getPubKeyHash();
-    		TimeLockedAddressEntity address = keyService.getTimeLockedAddressByAddressHash(addressHash);
-    		if (address == null) {
-                // unknown input (maybe not locked)
-                return false;
-            }
-            if (BitcoinUtils.isAfterLockTime(
-                    Utils.currentTimeSeconds()- LOCK_THRESHOLD_MILLIS/1000,
-                    address.getLockTime())) {
-                // locktime expired
-                return false;
-            }
-    	}
-    	
-    	return true;
+		for (TransactionInput input : inputs) {
+			TransactionOutput output = walletService.findOutputFor(input);
+			if (output == null) {
+				LOG.debug("Cannot determine whether output is locked or not (Tx not connected).");
+				return false;
+			}
+
+			byte[] addressHash = output.getScriptPubKey().getPubKeyHash();
+			TimeLockedAddressEntity address = keyService.getTimeLockedAddressByAddressHash(addressHash);
+			if (address == null) {
+				// unknown input (maybe not locked)
+				return false;
+			}
+			if (BitcoinUtils.isAfterLockTime(Utils.currentTimeSeconds() - LOCK_THRESHOLD_MILLIS / 1000,
+					address.getLockTime())) {
+				// locktime expired
+				return false;
+			}
+		}
+
+		return true;
 	}
 
-	private boolean signedExactlyOnce(final List<Transaction> clientTransactions, 
-									  final List<TransactionInput> inputsToCheck) {
+	private boolean signedExactlyOnce(final List<Transaction> clientTransactions,
+			final List<TransactionInput> inputsToCheck) {
 		final long currentTime = System.currentTimeMillis();
 		// check double signing:
-		// for each input (outpoint), go through all transactions and compare the outpoints.
+		// for each input (outpoint), go through all transactions and compare
+		// the outpoints.
 		for (TransactionInput relevantTxIn : inputsToCheck) {
 			int numSigned = 0;
 			for (Transaction storedTx : clientTransactions) {
 				final long lockTimeMillis = storedTx.getLockTime() * 1000;
-	            // ignore if we have a locktime in the future
-	            if (lockTimeMillis > currentTime + LOCK_THRESHOLD_MILLIS) {
-	                continue;
-	            }
+				// ignore if we have a locktime in the future
+				if (lockTimeMillis > currentTime + LOCK_THRESHOLD_MILLIS) {
+					continue;
+				}
 				for (TransactionInput storedTxIn : storedTx.getInputs()) {
 					if (storedTxIn.getOutpoint().equals(relevantTxIn.getOutpoint())) {
 						numSigned++;
-                        // abort early
-                        if(numSigned > 1) {
-                            return false;
-                        }
-                    }
+						// abort early
+						if (numSigned > 1) {
+							return false;
+						}
+					}
 				}
 			}
 			// not signed exactly once
@@ -341,67 +334,67 @@ public class TransactionService {
 				return false;
 			}
 		}
-		
+
 		return true;
-    }
-    
-    @Transactional(readOnly = true)
-    public boolean isBurned(NetworkParameters params, byte[] pubKey, Transaction fullTx) {
-        //check for already approved outpoints, if we have, we won't sign
-        final List<Transaction> approvedTxs = listTransactions(params, pubKey, true);
-        final List<TransactionOutPoint> burned = new ArrayList<>(approvedTxs.size());
-        for (final Transaction approvedTx : approvedTxs) {
-            for (final TransactionInput txInput : approvedTx.getInputs()) {
-                burned.add(txInput.getOutpoint());
-            }
-        }
-        final List<TransactionOutPoint> currents = new ArrayList<>();
-        for (final TransactionInput txInput : fullTx.getInputs()) {
-            currents.add(txInput.getOutpoint());
-        }
-        for (final TransactionOutPoint current : currents) {
-            if (burned.contains(current)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    @Transactional(readOnly = false)
-    public void addTransaction(byte[] clientPublicKey, byte[] tx, byte[] txHash, boolean approved) {
-        Tx transaction = new Tx();
-        transaction.clientPublicKey(clientPublicKey);
-        transaction.tx(tx);
-        transaction.txHash(txHash);
-        transaction.creationDate(new Date());
-        transaction.approved(approved);
-        repository.save(transaction);
-    }
-    
-    @Transactional(readOnly = false)
-    public void removeTransaction(Transaction tx) {
-        repository.delete(tx.getHash().getBytes());
-    }
+	}
 
-    private List<Transaction> listTransactions(final NetworkParameters params, 
-            final byte[] clientPublicKey, final boolean approved) {
-        final List<Tx> list = repository.findByClientPublicKeyAndApproved(clientPublicKey, approved);
-        final List<Transaction> retVal = new ArrayList<>(list.size());
-        for (final Tx enityTx : list) {
-            final Transaction tx = new Transaction(params, enityTx.tx());
-            retVal.add(tx);
-        }
-        return retVal;
-    }
+	@Transactional(readOnly = true)
+	public boolean isBurned(NetworkParameters params, byte[] pubKey, Transaction fullTx) {
+		// check for already approved outpoints, if we have, we won't sign
+		final List<Transaction> approvedTxs = listTransactions(params, pubKey, true);
+		final List<TransactionOutPoint> burned = new ArrayList<>(approvedTxs.size());
+		for (final Transaction approvedTx : approvedTxs) {
+			for (final TransactionInput txInput : approvedTx.getInputs()) {
+				burned.add(txInput.getOutpoint());
+			}
+		}
+		final List<TransactionOutPoint> currents = new ArrayList<>();
+		for (final TransactionInput txInput : fullTx.getInputs()) {
+			currents.add(txInput.getOutpoint());
+		}
+		for (final TransactionOutPoint current : currents) {
+			if (burned.contains(current)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    @Transactional(readOnly = true)
-    public List<Transaction> listApprovedTransactions(final NetworkParameters params) {
-        final List<Tx> approved = repository.findByApproved(true);
-        final List<Transaction> retVal = new ArrayList<>(approved.size());
-        for (final Tx approvedTx : approved) {
-            final Transaction tx = new Transaction(params, approvedTx.tx());
-            retVal.add(tx);
-        }
-        return retVal;
-    }
+	@Transactional(readOnly = false)
+	public void addTransaction(byte[] clientPublicKey, byte[] tx, byte[] txHash, boolean approved) {
+		Tx transaction = new Tx();
+		transaction.clientPublicKey(clientPublicKey);
+		transaction.tx(tx);
+		transaction.txHash(txHash);
+		transaction.creationDate(new Date());
+		transaction.approved(approved);
+		repository.save(transaction);
+	}
+
+	@Transactional(readOnly = false)
+	public void removeTransaction(Transaction tx) {
+		repository.delete(tx.getHash().getBytes());
+	}
+
+	private List<Transaction> listTransactions(final NetworkParameters params, final byte[] clientPublicKey,
+			final boolean approved) {
+		final List<Tx> list = repository.findByClientPublicKeyAndApproved(clientPublicKey, approved);
+		final List<Transaction> retVal = new ArrayList<>(list.size());
+		for (final Tx enityTx : list) {
+			final Transaction tx = new Transaction(params, enityTx.tx());
+			retVal.add(tx);
+		}
+		return retVal;
+	}
+
+	@Transactional(readOnly = true)
+	public List<Transaction> listApprovedTransactions(final NetworkParameters params) {
+		final List<Tx> approved = repository.findByApproved(true);
+		final List<Transaction> retVal = new ArrayList<>(approved.size());
+		for (final Tx approvedTx : approved) {
+			final Transaction tx = new Transaction(params, approvedTx.tx());
+			retVal.add(tx);
+		}
+		return retVal;
+	}
 }

--- a/src/main/java/com/coinblesk/server/service/TxQueueService.java
+++ b/src/main/java/com/coinblesk/server/service/TxQueueService.java
@@ -5,16 +5,18 @@
  */
 package com.coinblesk.server.service;
 
-import com.coinblesk.server.dao.TxQueueRepository;
-import com.coinblesk.server.entity.TxQueue;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.coinblesk.server.dao.TxQueueRepository;
+import com.coinblesk.server.entity.TxQueue;
 
 /**
  *
@@ -23,30 +25,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TxQueueService {
 
-    @Autowired
-    private TxQueueRepository repository;
+	@Autowired
+	private TxQueueRepository repository;
 
-    @Transactional(readOnly = false)
-    public void addTx(Transaction tx) {
-        TxQueue entity = new TxQueue()
-                .tx(tx.unsafeBitcoinSerialize())
-                .txHash(tx.getHash().getBytes())
-                .creationDate(new Date());
-        repository.save(entity);
-    }
-    
-    @Transactional(readOnly = true)
-    public List<Transaction> all(NetworkParameters params) {
-        Iterable<TxQueue> txQueues = repository.findAll();
-        List<Transaction> retVal = new ArrayList<Transaction>();
-        for(TxQueue txQueue:txQueues) {
-            retVal.add(new Transaction(params, txQueue.tx()));
-        }
-        return retVal;
-    }
-    
-    @Transactional(readOnly = false)
-    public void removeTx(Transaction tx) {
-        repository.delete(tx.getHash().getBytes());
-    }
+	@Transactional(readOnly = false)
+	public void addTx(Transaction tx) {
+		TxQueue entity = new TxQueue()
+				.tx(tx.unsafeBitcoinSerialize())
+				.txHash(tx.getHash().getBytes())
+				.creationDate(new Date());
+		repository.save(entity);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Transaction> all(NetworkParameters params) {
+		Iterable<TxQueue> txQueues = repository.findAll();
+		List<Transaction> retVal = new ArrayList<Transaction>();
+		for (TxQueue txQueue : txQueues) {
+			retVal.add(new Transaction(params, txQueue.tx()));
+		}
+		return retVal;
+	}
+
+	@Transactional(readOnly = false)
+	public void removeTx(Transaction tx) {
+		repository.delete(tx.getHash().getBytes());
+	}
 }

--- a/src/main/java/com/coinblesk/server/service/UserAccountService.java
+++ b/src/main/java/com/coinblesk/server/service/UserAccountService.java
@@ -15,24 +15,13 @@
  */
 package com.coinblesk.server.service;
 
-import com.coinblesk.server.dao.UserAccountRepository;
-import com.coinblesk.server.entity.UserAccount;
-import com.coinblesk.json.v1.Type;
-import com.coinblesk.json.v1.UserAccountStatusTO;
-import com.coinblesk.json.v1.UserAccountTO;
-import com.coinblesk.server.config.AppConfig;
-import com.coinblesk.server.config.UserRole;
-import com.coinblesk.server.entity.Keys;
-import com.coinblesk.util.BitcoinUtils;
-import com.coinblesk.util.CoinbleskException;
-import com.coinblesk.util.InsufficientFunds;
-import com.coinblesk.util.Pair;
 import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
@@ -44,256 +33,272 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.coinblesk.json.v1.Type;
+import com.coinblesk.json.v1.UserAccountStatusTO;
+import com.coinblesk.json.v1.UserAccountTO;
+import com.coinblesk.server.config.AppConfig;
+import com.coinblesk.server.config.UserRole;
+import com.coinblesk.server.dao.UserAccountRepository;
+import com.coinblesk.server.entity.Keys;
+import com.coinblesk.server.entity.UserAccount;
+import com.coinblesk.util.BitcoinUtils;
+import com.coinblesk.util.CoinbleskException;
+import com.coinblesk.util.InsufficientFunds;
+import com.coinblesk.util.Pair;
+
 /**
  *
  * @author draft
  */
 @Service
 public class UserAccountService {
-    
-    private final static SecureRandom random = new SecureRandom();
 
-    //as senn in: http://www.mkyong.com/regular-expressions/how-to-validate-email-address-with-regular-expression/
-    public static final String EMAIL_PATTERN
-            = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
-            + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
-    
-    private final static Logger LOG = LoggerFactory.getLogger(UserAccountService.class);
+	private final static SecureRandom random = new SecureRandom();
 
-    @Autowired
-    private UserAccountRepository repository;
+	// as senn in:
+	// http://www.mkyong.com/regular-expressions/how-to-validate-email-address-with-regular-expression/
+	public static final String EMAIL_PATTERN = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
+			+ "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+	private final static Logger LOG = LoggerFactory.getLogger(UserAccountService.class);
 
-    @Autowired
-    private MailService mailService;
-    
-    @Autowired
-    private AppConfig appConfig;
-    
-    @Autowired
-    private WalletService walletService;
-    
-    @Autowired
-    private KeyService keyService;
+	@Autowired
+	private UserAccountRepository repository;
 
-    @Transactional(readOnly = true)
-    public UserAccount getByEmail(String email) {
-        return repository.findByEmail(email);
-    }
+	@Autowired
+	private PasswordEncoder passwordEncoder;
 
-    //TODO: only used for testing. remove if possible
-    @Transactional(readOnly = false)
-    public void save(UserAccount userAccount) {
-        repository.save(userAccount);
-    }
+	@Autowired
+	private MailService mailService;
 
-    @Transactional(readOnly = false)
-    public Pair<UserAccountStatusTO, UserAccount> create(final UserAccountTO userAccountTO) {
-        final String email = userAccountTO.email();
-        if (email == null) {
-            return new Pair<>(new UserAccountStatusTO().type(Type.NO_EMAIL), null);
-        }
-        if (!email.matches(EMAIL_PATTERN)) {
-            return new Pair<>(new UserAccountStatusTO().type(Type.INVALID_EMAIL), null);
-        }
-        if (userAccountTO.password() == null || userAccountTO.password().length() < 6) {
-            return new Pair<>(new UserAccountStatusTO().type(Type.PASSWORD_TOO_SHORT), null);
-        }
+	@Autowired
+	private AppConfig appConfig;
 
-        userAccountTO.balance(0);
-        return createEntity(userAccountTO);
-    }
-   
-    //call this for testing only directy!!
-    @Transactional(readOnly = false)
-    public Pair<UserAccountStatusTO, UserAccount> createEntity(final UserAccountTO userAccountTO) {
-        final String email = userAccountTO.email().toLowerCase(Locale.ENGLISH);
-        final UserAccount found = repository.findByEmail(email);
-        if (found != null) {
-            if (found.getEmailToken() != null) {
-                return new Pair<>(new UserAccountStatusTO().type(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED), found);
-            }
-            return new Pair<>(new UserAccountStatusTO().type(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_ACTIVATED), found);
-        }
-        //convert TO to Entity
-        UserAccount userAccount = new UserAccount();
-        userAccount.setEmail(email);
-        userAccount.setPassword(passwordEncoder.encode(userAccountTO.password()));
-        userAccount.setCreationDate(new Date());
-        userAccount.setDeleted(false);
-        userAccount.setEmailToken(UUID.randomUUID().toString());
-        userAccount.setUserRole(UserRole.USER);
-        userAccount.setBalance(BigDecimal.valueOf(
-                userAccountTO.balance()).divide(BigDecimal.valueOf(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI)));
-        repository.save(userAccount);
-        return new Pair<>(new UserAccountStatusTO().setSuccess(), userAccount);
-    }
+	@Autowired
+	private WalletService walletService;
 
-    @Transactional(readOnly = false)
-    public UserAccountStatusTO activate(String email, String token) {
-        final UserAccount found = repository.findByEmail(email);
-        if (found == null) {
-            //no such email address - notok
-            return new UserAccountStatusTO().type(Type.NO_EMAIL);
-        }
-        if (found.getEmailToken() == null) {
-            //already acitaveted - ok
-            return new UserAccountStatusTO().setSuccess();
-        }
+	@Autowired
+	private KeyService keyService;
 
-        if (!found.getEmailToken().equals(token)) {
-            //wrong token - notok
-            return new UserAccountStatusTO().type(Type.INVALID_EMAIL_TOKEN);
-        }
+	@Transactional(readOnly = true)
+	public UserAccount getByEmail(String email) {
+		return repository.findByEmail(email);
+	}
 
-        //activate, enitiy is in attached state
-        found.setEmailToken(null);
-        return new UserAccountStatusTO().setSuccess();
-    }
+	// TODO: only used for testing. remove if possible
+	@Transactional(readOnly = false)
+	public void save(UserAccount userAccount) {
+		repository.save(userAccount);
+	}
 
-    @Transactional(readOnly = false)
-    public UserAccountStatusTO delete(String email) {
-        
-        final UserAccount found = repository.findByEmail(email);
-        if (found == null) {
-            //no such email address - notok
-            return new UserAccountStatusTO().type(Type.NO_EMAIL);
-        }
-        found.setDeleted(true);
-        return new UserAccountStatusTO().setSuccess();
-    }
+	@Transactional(readOnly = false)
+	public Pair<UserAccountStatusTO, UserAccount> create(final UserAccountTO userAccountTO) {
+		final String email = userAccountTO.email();
+		if (email == null) {
+			return new Pair<>(new UserAccountStatusTO().type(Type.NO_EMAIL), null);
+		}
+		if (!email.matches(EMAIL_PATTERN)) {
+			return new Pair<>(new UserAccountStatusTO().type(Type.INVALID_EMAIL), null);
+		}
+		if (userAccountTO.password() == null || userAccountTO.password().length() < 6) {
+			return new Pair<>(new UserAccountStatusTO().type(Type.PASSWORD_TOO_SHORT), null);
+		}
 
-    @Transactional(readOnly = true)
-    public UserAccountTO get(String email) {
-        final UserAccount userAccount = repository.findByEmail(email);
-        if (userAccount == null) {
-            return null;
-        }
-        long satoshi = userAccount.getBalance().multiply(new BigDecimal(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI)).longValue();
-        final UserAccountTO userAccountTO = new UserAccountTO();
-        userAccountTO
-                .email(userAccount.getEmail())
-                .balance(satoshi);
-        return userAccountTO;
-    }
-    
-    @Transactional(readOnly = false)
-    public UserAccountTO transferP2SH(ECKey clientKey, String email) {
-        final NetworkParameters params = appConfig.getNetworkParameters();
-        final UserAccount userAccount = repository.findByEmail(email);
-        if (userAccount == null) {
-            return new UserAccountTO().type(Type.NO_ACCOUNT);
-        }
-        final ECKey pot = appConfig.getPotPrivateKeyAddress();
-        long satoshi = userAccount.getBalance().multiply(new BigDecimal(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI)).longValue();
-        
-        List<TransactionOutput> outputs = walletService.potTransactionOutput(params);
-        
-        //TODO: get current timelocked multisig address
-        Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-        Transaction tx;
-        try {
-            tx = BitcoinUtils.createTx(params, outputs, pot.toAddress(params), 
-                keys.latestTimeLockedAddresses().toAddress(params), satoshi, false);
-            
-            tx = BitcoinUtils.sign(params, tx, pot);
-            BitcoinUtils.verifyTxFull(tx);
-            LOG.debug("About tot zero balance with tx {}", tx);
-            userAccount.setBalance(BigDecimal.ZERO);
-            LOG.debug("About to broadcast tx");
-            walletService.broadcast(tx);
-            LOG.debug("Broadcast done");
-            long satoshiNew = userAccount.getBalance().multiply(new BigDecimal(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI)).longValue();
-            
-            final UserAccountTO userAccountTO = new UserAccountTO();
-            userAccountTO
-                .email(userAccount.getEmail())
-                .balance(satoshiNew);
-            return userAccountTO;
-        } catch (CoinbleskException | InsufficientFunds e) {
-            LOG.error("Cannot create transaction", e);
-            mailService.sendAdminMail("transfer-p2sh error", "Cannot create transaction: "+e.getMessage());
-            return new UserAccountTO().type(Type.ACCOUNT_ERROR).message(e.getMessage());
-        }
-    }
+		userAccountTO.balance(0);
+		return createEntity(userAccountTO);
+	}
 
-    //for debugging
-    @Transactional(readOnly = true)
-    public String getToken(String email) {
-        final UserAccount userAccount = repository.findByEmail(email);
-        if (userAccount == null) {
-            return null;
-        }
-        return userAccount.getEmailToken();
-    }
+	// call this for testing only directy!!
+	@Transactional(readOnly = false)
+	public Pair<UserAccountStatusTO, UserAccount> createEntity(final UserAccountTO userAccountTO) {
+		final String email = userAccountTO.email().toLowerCase(Locale.ENGLISH);
+		final UserAccount found = repository.findByEmail(email);
+		if (found != null) {
+			if (found.getEmailToken() != null) {
+				return new Pair<>(new UserAccountStatusTO().type(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED),
+						found);
+			}
+			return new Pair<>(new UserAccountStatusTO().type(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_ACTIVATED), found);
+		}
+		// convert TO to Entity
+		UserAccount userAccount = new UserAccount();
+		userAccount.setEmail(email);
+		userAccount.setPassword(passwordEncoder.encode(userAccountTO.password()));
+		userAccount.setCreationDate(new Date());
+		userAccount.setDeleted(false);
+		userAccount.setEmailToken(UUID.randomUUID().toString());
+		userAccount.setUserRole(UserRole.USER);
+		userAccount.setBalance(BigDecimal.valueOf(userAccountTO.balance())
+				.divide(BigDecimal.valueOf(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI)));
+		repository.save(userAccount);
+		return new Pair<>(new UserAccountStatusTO().setSuccess(), userAccount);
+	}
 
-    @Transactional(readOnly = false)
-    public UserAccountStatusTO changePassword(String email, String password) {
-        final UserAccount found = repository.findByEmail(email);
-        if (found == null) {
-            //no such email address - notok
-            return new UserAccountStatusTO().type(Type.NO_EMAIL);
-        }
-        found.setPassword(passwordEncoder.encode(password));
-        return new UserAccountStatusTO().setSuccess();
-    }
-    
-    @Transactional(readOnly = false)
-    public UserAccountStatusTO activateForgot(String email, String forgetToken) {
-        final UserAccount found = repository.findByEmail(email);
-        if (found == null) {
-            //no such email address - notok
-            return new UserAccountStatusTO().type(Type.NO_EMAIL);
-        }
-        if (found.getForgotEmailToken() == null) {
-            //wrong no password forget requested
-            return new UserAccountStatusTO().type(Type.INVALID_EMAIL_TOKEN);
-        }
-        
-        if (!found.getForgotEmailToken().equals(forgetToken)) {
-            //wrong token - notok
-            return new UserAccountStatusTO().type(Type.INVALID_EMAIL_TOKEN);
-        }
-        
-        //activate, change password
-        found.setForgotEmailToken(null);
-        found.setPassword(found.getForgotPassword());
-        
-        return new UserAccountStatusTO().setSuccess();
-    }
+	@Transactional(readOnly = false)
+	public UserAccountStatusTO activate(String email, String token) {
+		final UserAccount found = repository.findByEmail(email);
+		if (found == null) {
+			// no such email address - notok
+			return new UserAccountStatusTO().type(Type.NO_EMAIL);
+		}
+		if (found.getEmailToken() == null) {
+			// already acitaveted - ok
+			return new UserAccountStatusTO().setSuccess();
+		}
 
-    @Transactional(readOnly = false)
-    public Pair<UserAccountStatusTO, UserAccountTO> forgot(String email) {
-        final UserAccount found = repository.findByEmail(email);
-        if (found == null) {
-            LOG.debug("no such email found in DB {}", email);
-            //no such email address - notok
-            return new Pair<UserAccountStatusTO, UserAccountTO>(new UserAccountStatusTO().type(Type.NO_EMAIL), null);
-        }
-        String password = createPassword();
-        found.setForgotPassword(passwordEncoder.encode(password));
-        String token = UUID.randomUUID().toString();
-        found.setForgotEmailToken(token);
-        UserAccountTO to = new UserAccountTO();
-        to.email(found.getEmail());
-        to.password(password);
-        to.message(token);
-        return new Pair<UserAccountStatusTO, UserAccountTO>(new UserAccountStatusTO().setSuccess(), to);
-    }
- 
-    private static String createPassword() {
-        // put here all characters that are allowed in password
-        final char[] ALLOWED_CHARACTERS = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ123456789".toCharArray();
-        final int PASSWORD_LENGTH = 8;
-        
-        final StringBuffer password = new StringBuffer();
+		if (!found.getEmailToken().equals(token)) {
+			// wrong token - notok
+			return new UserAccountStatusTO().type(Type.INVALID_EMAIL_TOKEN);
+		}
 
-        final int len = ALLOWED_CHARACTERS.length;
-        for(int i = 0; i < PASSWORD_LENGTH; i++) {
-            password.append(ALLOWED_CHARACTERS[ random.nextInt(len) ]);
-        }
-        return password.toString();
-    }
+		// activate, enitiy is in attached state
+		found.setEmailToken(null);
+		return new UserAccountStatusTO().setSuccess();
+	}
+
+	@Transactional(readOnly = false)
+	public UserAccountStatusTO delete(String email) {
+
+		final UserAccount found = repository.findByEmail(email);
+		if (found == null) {
+			// no such email address - notok
+			return new UserAccountStatusTO().type(Type.NO_EMAIL);
+		}
+		found.setDeleted(true);
+		return new UserAccountStatusTO().setSuccess();
+	}
+
+	@Transactional(readOnly = true)
+	public UserAccountTO get(String email) {
+		final UserAccount userAccount = repository.findByEmail(email);
+		if (userAccount == null) {
+			return null;
+		}
+		long satoshi = userAccount.getBalance()
+				.multiply(new BigDecimal(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI))
+				.longValue();
+		final UserAccountTO userAccountTO = new UserAccountTO();
+		userAccountTO.email(userAccount.getEmail()).balance(satoshi);
+		return userAccountTO;
+	}
+
+	@Transactional(readOnly = false)
+	public UserAccountTO transferP2SH(ECKey clientKey, String email) {
+		final NetworkParameters params = appConfig.getNetworkParameters();
+		final UserAccount userAccount = repository.findByEmail(email);
+		if (userAccount == null) {
+			return new UserAccountTO().type(Type.NO_ACCOUNT);
+		}
+		final ECKey pot = appConfig.getPotPrivateKeyAddress();
+		long satoshi = userAccount.getBalance()
+				.multiply(new BigDecimal(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI))
+				.longValue();
+
+		List<TransactionOutput> outputs = walletService.potTransactionOutput(params);
+
+		// TODO: get current timelocked multisig address
+		Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+		Transaction tx;
+		try {
+			tx = BitcoinUtils.createTx(params, outputs, pot.toAddress(params),
+					keys.latestTimeLockedAddresses().toAddress(params), satoshi, false);
+
+			tx = BitcoinUtils.sign(params, tx, pot);
+			BitcoinUtils.verifyTxFull(tx);
+			LOG.debug("About tot zero balance with tx {}", tx);
+			userAccount.setBalance(BigDecimal.ZERO);
+			LOG.debug("About to broadcast tx");
+			walletService.broadcast(tx);
+			LOG.debug("Broadcast done");
+			long satoshiNew = userAccount.getBalance()
+					.multiply(new BigDecimal(BitcoinUtils.ONE_BITCOIN_IN_SATOSHI))
+					.longValue();
+
+			final UserAccountTO userAccountTO = new UserAccountTO();
+			userAccountTO.email(userAccount.getEmail()).balance(satoshiNew);
+			return userAccountTO;
+		} catch (CoinbleskException | InsufficientFunds e) {
+			LOG.error("Cannot create transaction", e);
+			mailService.sendAdminMail("transfer-p2sh error", "Cannot create transaction: " + e.getMessage());
+			return new UserAccountTO().type(Type.ACCOUNT_ERROR).message(e.getMessage());
+		}
+	}
+
+	// for debugging
+	@Transactional(readOnly = true)
+	public String getToken(String email) {
+		final UserAccount userAccount = repository.findByEmail(email);
+		if (userAccount == null) {
+			return null;
+		}
+		return userAccount.getEmailToken();
+	}
+
+	@Transactional(readOnly = false)
+	public UserAccountStatusTO changePassword(String email, String password) {
+		final UserAccount found = repository.findByEmail(email);
+		if (found == null) {
+			// no such email address - notok
+			return new UserAccountStatusTO().type(Type.NO_EMAIL);
+		}
+		found.setPassword(passwordEncoder.encode(password));
+		return new UserAccountStatusTO().setSuccess();
+	}
+
+	@Transactional(readOnly = false)
+	public UserAccountStatusTO activateForgot(String email, String forgetToken) {
+		final UserAccount found = repository.findByEmail(email);
+		if (found == null) {
+			// no such email address - notok
+			return new UserAccountStatusTO().type(Type.NO_EMAIL);
+		}
+		if (found.getForgotEmailToken() == null) {
+			// wrong no password forget requested
+			return new UserAccountStatusTO().type(Type.INVALID_EMAIL_TOKEN);
+		}
+
+		if (!found.getForgotEmailToken().equals(forgetToken)) {
+			// wrong token - notok
+			return new UserAccountStatusTO().type(Type.INVALID_EMAIL_TOKEN);
+		}
+
+		// activate, change password
+		found.setForgotEmailToken(null);
+		found.setPassword(found.getForgotPassword());
+
+		return new UserAccountStatusTO().setSuccess();
+	}
+
+	@Transactional(readOnly = false)
+	public Pair<UserAccountStatusTO, UserAccountTO> forgot(String email) {
+		final UserAccount found = repository.findByEmail(email);
+		if (found == null) {
+			LOG.debug("no such email found in DB {}", email);
+			// no such email address - notok
+			return new Pair<UserAccountStatusTO, UserAccountTO>(new UserAccountStatusTO().type(Type.NO_EMAIL), null);
+		}
+		String password = createPassword();
+		found.setForgotPassword(passwordEncoder.encode(password));
+		String token = UUID.randomUUID().toString();
+		found.setForgotEmailToken(token);
+		UserAccountTO to = new UserAccountTO();
+		to.email(found.getEmail());
+		to.password(password);
+		to.message(token);
+		return new Pair<UserAccountStatusTO, UserAccountTO>(new UserAccountStatusTO().setSuccess(), to);
+	}
+
+	private static String createPassword() {
+		// put here all characters that are allowed in password
+		final char[] ALLOWED_CHARACTERS = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ123456789".toCharArray();
+		final int PASSWORD_LENGTH = 8;
+
+		final StringBuffer password = new StringBuffer();
+
+		final int len = ALLOWED_CHARACTERS.length;
+		for (int i = 0; i < PASSWORD_LENGTH; i++) {
+			password.append(ALLOWED_CHARACTERS[random.nextInt(len)]);
+		}
+		return password.toString();
+	}
 }

--- a/src/main/java/com/coinblesk/server/service/WalletService.java
+++ b/src/main/java/com/coinblesk/server/service/WalletService.java
@@ -18,16 +18,33 @@ package com.coinblesk.server.service;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.bitcoinj.core.*;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionBroadcast;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.script.Script;
@@ -54,11 +71,6 @@ import com.coinblesk.server.entity.TimeLockedAddressEntity;
 import com.coinblesk.util.BitcoinUtils;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-
 
 /**
  *
@@ -67,387 +79,391 @@ import java.util.Set;
 @Service
 public class WalletService {
 
-    private final static Logger LOG = LoggerFactory.getLogger(WalletService.class);
+	private final static Logger LOG = LoggerFactory.getLogger(WalletService.class);
 
-    @Autowired
-    private AppConfig appConfig;
+	@Autowired
+	private AppConfig appConfig;
 
-    @Autowired
-    private KeyService keyService;
+	@Autowired
+	private KeyService keyService;
 
-    @Autowired
-    private TransactionService transactionService;
-    
-    @Autowired
-    private TxQueueService txQueueService;
+	@Autowired
+	private TransactionService transactionService;
 
-    private Wallet wallet;
+	@Autowired
+	private TxQueueService txQueueService;
 
-    private BlockChain blockChain;
+	private Wallet wallet;
 
-    private PeerGroup peerGroup;
+	private BlockChain blockChain;
 
-    private BlockStore blockStore;
-    
-    private Set<Sha256Hash> removed = Collections.synchronizedSet(new HashSet<Sha256Hash>());
+	private PeerGroup peerGroup;
 
-    @PostConstruct
-    public void init() throws IOException, UnreadableWalletException, BlockStoreException, InterruptedException {
-        final NetworkParameters params = appConfig.getNetworkParameters();
+	private BlockStore blockStore;
 
-        // Create config directory if necessary
-        final File directory = appConfig.getConfigDir().getFile();
-        if (!directory.exists()) {
-            if (!directory.mkdirs()) {
-                throw new IOException("Could not create directory " + directory.getAbsolutePath());
-            }
-        }
-        // Init chain and wallet files
-        final File chainFile = new File(directory, "coinblesk2-" + appConfig.getBitcoinNet() + ".spvchain");
-        final File walletFile = new File(directory, "coinblesk2-" + appConfig.getBitcoinNet() + ".wallet");
+	private Set<Sha256Hash> removed = Collections.synchronizedSet(new HashSet<Sha256Hash>());
 
-        // Delete chain and wallet file when using UNITTEST network
-        if (appConfig.getBitcoinNet() == BitcoinNet.UNITTEST) {
-            chainFile.delete();
-            walletFile.delete();
-            LOG.info("Deleted file {} and {}", chainFile.getName(), walletFile.getName());
-        }
+	@PostConstruct
+	public void init() throws IOException, UnreadableWalletException, BlockStoreException, InterruptedException {
+		final NetworkParameters params = appConfig.getNetworkParameters();
 
-        if (walletFile.exists()) {
-            wallet = Wallet.loadFromFile(walletFile);
-            if (!chainFile.exists()) {
-                wallet.reset();
-            }
-        } else {
-            //TODO: add keychaingroup for restoring wallet
-            wallet = new Wallet(params);
-        }
-        wallet.autosaveToFile(walletFile, 5, TimeUnit.SECONDS, null);
+		// Create config directory if necessary
+		final File directory = appConfig.getConfigDir().getFile();
+		if (!directory.exists()) {
+			if (!directory.mkdirs()) {
+				throw new IOException("Could not create directory " + directory.getAbsolutePath());
+			}
+		}
+		// Init chain and wallet files
+		final File chainFile = new File(directory, "coinblesk2-" + appConfig.getBitcoinNet() + ".spvchain");
+		final File walletFile = new File(directory, "coinblesk2-" + appConfig.getBitcoinNet() + ".wallet");
 
-        walletWatchKeysP2SH(params);
-        walletWatchKeysCLTV(params);
-        walletWatchKeysPot(params);
-        
-        blockStore = new SPVBlockStore(params, chainFile);
-        blockChain = new BlockChain(params, blockStore);
-        peerGroup = new PeerGroup(params, blockChain);
+		// Delete chain and wallet file when using UNITTEST network
+		if (appConfig.getBitcoinNet() == BitcoinNet.UNITTEST) {
+			chainFile.delete();
+			walletFile.delete();
+			LOG.info("Deleted file {} and {}", chainFile.getName(), walletFile.getName());
+		}
 
-        // Add own fullnode to list of seeds
-        String[] seeds = ArrayUtils.addAll(new String[] {appConfig.getFirstSeedNode()},params.getDnsSeeds());
-        if (appConfig.getBitcoinNet() != BitcoinNet.MAINNET) {
-            DnsDiscovery discovery = new DnsDiscovery(seeds, params);
-            peerGroup.addPeerDiscovery(discovery);
-        }
+		if (walletFile.exists()) {
+			wallet = Wallet.loadFromFile(walletFile);
+			if (!chainFile.exists()) {
+				wallet.reset();
+			}
+		} else {
+			// TODO: add keychaingroup for restoring wallet
+			wallet = new Wallet(params);
+		}
+		wallet.autosaveToFile(walletFile, 5, TimeUnit.SECONDS, null);
 
-        blockChain.addWallet(wallet);
-        peerGroup.addWallet(wallet);
+		walletWatchKeysP2SH(params);
+		walletWatchKeysCLTV(params);
+		walletWatchKeysPot(params);
 
-        if (appConfig.getBitcoinNet() != BitcoinNet.UNITTEST) {
-            peerGroup.start();
-        }
+		blockStore = new SPVBlockStore(params, chainFile);
+		blockChain = new BlockChain(params, blockStore);
+		peerGroup = new PeerGroup(params, blockChain);
 
-        // Download block chain (blocking)
-        final DownloadProgressTracker downloadListener = new DownloadProgressTracker() {
-            @Override
-            protected void doneDownload() {
-                LOG.info("downloading done");
+		// Add own fullnode to list of seeds
+		String[] seeds = ArrayUtils.addAll(new String[] { appConfig.getFirstSeedNode() }, params.getDnsSeeds());
+		if (appConfig.getBitcoinNet() != BitcoinNet.MAINNET) {
+			DnsDiscovery discovery = new DnsDiscovery(seeds, params);
+			peerGroup.addPeerDiscovery(discovery);
+		}
 
-                //once we downloaded all the blocks we need to broadcast the stored approved tx
-                List<Transaction> txs = transactionService.listApprovedTransactions(params);
-                for(Transaction tx:txs) {
-                    broadcast(tx);
-                }
+		blockChain.addWallet(wallet);
+		peerGroup.addWallet(wallet);
 
-                // Be notified when the confidence of relevant transactions change (number of confirmations).
-                addConficenceChangedHandler();
-            }
+		if (appConfig.getBitcoinNet() != BitcoinNet.UNITTEST) {
+			peerGroup.start();
+		}
 
-            @Override
-            protected void progress(double pct, int blocksSoFar, Date date) {
-                LOG.info("downloading: {}%", (int)pct);
-            }
+		// Download block chain (blocking)
+		final DownloadProgressTracker downloadListener = new DownloadProgressTracker() {
+			@Override
+			protected void doneDownload() {
+				LOG.info("downloading done");
 
-        };
+				// once we downloaded all the blocks we need to broadcast the
+				// stored approved tx
+				List<Transaction> txs = transactionService.listApprovedTransactions(params);
+				for (Transaction tx : txs) {
+					broadcast(tx);
+				}
 
-        if (appConfig.getBitcoinNet() != BitcoinNet.UNITTEST) {
-            peerGroup.startBlockChainDownload(downloadListener);
-            downloadListener.await();
-        }
+				// Be notified when the confidence of relevant transactions
+				// change (number of confirmations).
+				addConficenceChangedHandler();
+			}
 
-        // Broadcast pending transactions
-        pendingTransactions();
+			@Override
+			protected void progress(double pct, int blocksSoFar, Date date) {
+				LOG.info("downloading: {}%", (int) pct);
+			}
 
-        LOG.info("wallet init done.");
-    } 
+		};
+
+		if (appConfig.getBitcoinNet() != BitcoinNet.UNITTEST) {
+			peerGroup.startBlockChainDownload(downloadListener);
+			downloadListener.await();
+		}
+
+		// Broadcast pending transactions
+		pendingTransactions();
+
+		LOG.info("wallet init done.");
+	}
 
 	private void walletWatchKeysP2SH(final NetworkParameters params) {
 		StringBuilder sb = new StringBuilder();
-        final List<List<ECKey>> all = keyService.all();
-        final List<Script> scripts = new ArrayList<>();
-        for (List<ECKey> keys : all) {
-            final Script script = BitcoinUtils.createP2SHOutputScript(2, keys);
-            script.setCreationTimeSeconds(0);
-            scripts.add(script);
-            sb.append(script.getToAddress(params)).append("\n");
-        }
-        wallet.addWatchedScripts(scripts);
-        LOG.info("walletWatchKeysP2SH:\n{}", sb.toString());
-    }
-    
-    private void walletWatchKeysCLTV(final NetworkParameters params) {
-    	StringBuilder sb = new StringBuilder();
-        for (Keys key : keyService.allKeys()) {
-        	for (TimeLockedAddressEntity address : key.timeLockedAddresses()) {
-        		wallet.addWatchedAddress(address.toAddress(params), address.getTimeCreated());
-        		sb.append(address.toAddress(params)).append("\n");
-        	}
-        }
-        LOG.info("walletWatchKeysCLTV:\n{}", sb.toString());
-    }
-    
-    private void walletWatchKeysPot(final NetworkParameters params) {
-        ECKey potAddress = appConfig.getPotPrivateKeyAddress();
-        wallet.addWatchedAddress(potAddress.toAddress(params), appConfig.getPotCreationTime());
-        LOG.info("walletWatchKeysPot: {}", potAddress.toAddress(params));
-    }
+		final List<List<ECKey>> all = keyService.all();
+		final List<Script> scripts = new ArrayList<>();
+		for (List<ECKey> keys : all) {
+			final Script script = BitcoinUtils.createP2SHOutputScript(2, keys);
+			script.setCreationTimeSeconds(0);
+			scripts.add(script);
+			sb.append(script.getToAddress(params)).append("\n");
+		}
+		wallet.addWatchedScripts(scripts);
+		LOG.info("walletWatchKeysP2SH:\n{}", sb.toString());
+	}
 
-    /***
-     * Add a listener for when a transaction we are watching's confidence changed due to a new block.
-     *
-     * After the transaction is {bitcoin.minconf} blocks deep, we remove the tx from the
-     * database, as it is considered safe.
-     *
-     * The method should only be called after complete download of the blockchain, since the handler is called for
-     * every block and transaction we are watching, which will result in high CPU and memory consumption and might
-     * exceed the JVM memory limit. After download is complete, blocks arrive only sporadically and this is not a
-     * problem.
-     */
-    private void addConficenceChangedHandler() {
-        // Use a custom thread pool to speed up the processing of transactions. Queue is blocking and limited to 10'000
-        // to avoid memory exhaustion. After threshold is reached, the CallerRunsPolicy() forces blocking behavior.
-        ContextPropagatingThreadFactory factory = new ContextPropagatingThreadFactory("listenerFactory");
-        Executor listenerExecutor = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), Runtime.getRuntime().availableProcessors(),
-                0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<Runnable>(10000),
-                factory, new ThreadPoolExecutor.CallerRunsPolicy());
+	private void walletWatchKeysCLTV(final NetworkParameters params) {
+		StringBuilder sb = new StringBuilder();
+		for (Keys key : keyService.allKeys()) {
+			for (TimeLockedAddressEntity address : key.timeLockedAddresses()) {
+				wallet.addWatchedAddress(address.toAddress(params), address.getTimeCreated());
+				sb.append(address.toAddress(params)).append("\n");
+			}
+		}
+		LOG.info("walletWatchKeysCLTV:\n{}", sb.toString());
+	}
 
-        wallet.addTransactionConfidenceEventListener(listenerExecutor, (wallet, tx) -> {
-            if (tx.getConfidence().getDepthInBlocks() >= appConfig.getMinConf() && !removed.contains(tx.getHash())) {
-                LOG.debug("remove tx we got from the network {}", tx);
+	private void walletWatchKeysPot(final NetworkParameters params) {
+		ECKey potAddress = appConfig.getPotPrivateKeyAddress();
+		wallet.addWatchedAddress(potAddress.toAddress(params), appConfig.getPotCreationTime());
+		LOG.info("walletWatchKeysPot: {}", potAddress.toAddress(params));
+	}
 
-                try {
-                    transactionService.removeTransaction(tx);
-                } catch (EmptyResultDataAccessException e) {
-                    LOG.debug("tx was not in tx table {}", tx);
-                }
+	/***
+	 * Add a listener for when a transaction we are watching's confidence
+	 * changed due to a new block.
+	 *
+	 * After the transaction is {bitcoin.minconf} blocks deep, we remove the tx
+	 * from the database, as it is considered safe.
+	 *
+	 * The method should only be called after complete download of the
+	 * blockchain, since the handler is called for every block and transaction
+	 * we are watching, which will result in high CPU and memory consumption and
+	 * might exceed the JVM memory limit. After download is complete, blocks
+	 * arrive only sporadically and this is not a problem.
+	 */
+	private void addConficenceChangedHandler() {
+		// Use a custom thread pool to speed up the processing of transactions.
+		// Queue is blocking and limited to 10'000
+		// to avoid memory exhaustion. After threshold is reached, the
+		// CallerRunsPolicy() forces blocking behavior.
+		ContextPropagatingThreadFactory factory = new ContextPropagatingThreadFactory("listenerFactory");
+		Executor listenerExecutor = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(),
+				Runtime.getRuntime().availableProcessors(), 0L, TimeUnit.MILLISECONDS,
+				new LinkedBlockingQueue<Runnable>(10000), factory, new ThreadPoolExecutor.CallerRunsPolicy());
 
-                try {
-                    txQueueService.removeTx(tx);
-                } catch (EmptyResultDataAccessException e) {
-                    LOG.debug("tx was not in txqueue table {}", tx);
-                }
+		wallet.addTransactionConfidenceEventListener(listenerExecutor, (wallet, tx) -> {
+			if (tx.getConfidence().getDepthInBlocks() >= appConfig.getMinConf() && !removed.contains(tx.getHash())) {
+				LOG.debug("remove tx we got from the network {}", tx);
 
-                removed.add(tx.getHash());
-            }
-        });
-    }
-    
-    public List<TransactionOutput> potTransactionOutput(final NetworkParameters params) {
-        ECKey potAddress = appConfig.getPotPrivateKeyAddress();
-        final List<TransactionOutput> retVal = new ArrayList<TransactionOutput>();
-        for(TransactionOutput output:wallet.getWatchedOutputs(true)) {
-            Address to = output.getScriptPubKey().getToAddress(params);
-            if(!to.isP2SHAddress()) {
-                if(to.equals(potAddress.toAddress(params))) {
-                    retVal.add(output);
-                }
-            }
-        }
-        return retVal;
-    }
+				try {
+					transactionService.removeTransaction(tx);
+				} catch (EmptyResultDataAccessException e) {
+					LOG.debug("tx was not in tx table {}", tx);
+				}
 
-    public BlockChain blockChain() {
-        return blockChain;
-    }
-    
-    public void addWatching(Address address) {
-        wallet.addWatchedAddress(address);
-    }
+				try {
+					txQueueService.removeTx(tx);
+				} catch (EmptyResultDataAccessException e) {
+					LOG.debug("tx was not in txqueue table {}", tx);
+				}
 
-    public void addWatching(Script script) {
-        List<Script> list = new ArrayList<>(1);
-        list.add(script);
-        wallet.addWatchedScripts(list);
-    }
+				removed.add(tx.getHash());
+			}
+		});
+	}
 
-    /**
-     * The unspent tx also contains spentOutputs, where the approved tx should mark the unspent as spent!
-     *
-     * @param params
-     * @return
-     */
-    @Transactional(readOnly = true)
-    public Map<Sha256Hash, Transaction> verifiedTransactions(NetworkParameters params) {
-        Map<Sha256Hash, Transaction> copy = new HashMap<>(wallet.getTransactionPool(
-                WalletTransaction.Pool.UNSPENT));
-        Map<Sha256Hash, Transaction> copy2 = new HashMap<>(copy);
-        //also add approved Tx
-        for (Transaction t : copy.values()) {
-            if (t.getConfidence().getDepthInBlocks() < appConfig.getMinConf()) {
-                LOG.debug("not enough confirmations for {}", t.getHash());
-                copy2.remove(t.getHash());
-            }
-        }
+	public List<TransactionOutput> potTransactionOutput(final NetworkParameters params) {
+		ECKey potAddress = appConfig.getPotPrivateKeyAddress();
+		final List<TransactionOutput> retVal = new ArrayList<TransactionOutput>();
+		for (TransactionOutput output : wallet.getWatchedOutputs(true)) {
+			Address to = output.getScriptPubKey().getToAddress(params);
+			if (!to.isP2SHAddress()) {
+				if (to.equals(potAddress.toAddress(params))) {
+					retVal.add(output);
+				}
+			}
+		}
+		return retVal;
+	}
 
-        for (Transaction t : copy2.values()) {
-            LOG.debug("unspent tx from Network: {}", t.getHash());
-        }
+	public BlockChain blockChain() {
+		return blockChain;
+	}
 
-        List<Transaction> approvedTx = transactionService.listApprovedTransactions(params);
-        for (Transaction t : approvedTx) {
-            LOG.debug("adding approved tx, which can be used for spending: {}", t);
-            copy2.put(t.getHash(), t);
-        }
-        return copy2;
-    }
+	public void addWatching(Address address) {
+		wallet.addWatchedAddress(address);
+	}
 
-    @Transactional(readOnly = true)
-    public List<TransactionOutput> verifiedOutputs(NetworkParameters params, Address p2shAddress) {
-        List<TransactionOutput> retVal = new ArrayList<>();
+	public void addWatching(Script script) {
+		List<Script> list = new ArrayList<>(1);
+		list.add(script);
+		wallet.addWatchedScripts(list);
+	}
 
-        Map<Sha256Hash, Transaction> unspent = verifiedTransactions(params);
+	/**
+	 * The unspent tx also contains spentOutputs, where the approved tx should
+	 * mark the unspent as spent!
+	 *
+	 * @param params
+	 * @return
+	 */
+	@Transactional(readOnly = true)
+	public Map<Sha256Hash, Transaction> verifiedTransactions(NetworkParameters params) {
+		Map<Sha256Hash, Transaction> copy = new HashMap<>(wallet.getTransactionPool(WalletTransaction.Pool.UNSPENT));
+		Map<Sha256Hash, Transaction> copy2 = new HashMap<>(copy);
+		// also add approved Tx
+		for (Transaction t : copy.values()) {
+			if (t.getConfidence().getDepthInBlocks() < appConfig.getMinConf()) {
+				LOG.debug("not enough confirmations for {}", t.getHash());
+				copy2.remove(t.getHash());
+			}
+		}
 
-        for (Transaction t : unspent.values()) {
-            for (TransactionOutput out : t.getOutputs()) {
-                if (p2shAddress.equals(out.getAddressFromP2SH(appConfig.getNetworkParameters()))) {
-                    if (out.isAvailableForSpending()) {
-                        //now check if not spent
-                        retVal.add(out);
-                        LOG
-                                .debug("this txout is unspent : {}, point: {}, spent {}", out, out
-                                        .getOutPointFor());
-                    } else {
-                        LOG.debug("this txout is spent!: {}, point: {}out.getOutPointFor()", out, out
-                                .getOutPointFor());
-                    }
-                }
-            }
-        }
+		for (Transaction t : copy2.values()) {
+			LOG.debug("unspent tx from Network: {}", t.getHash());
+		}
 
-        return retVal;
-    }
+		List<Transaction> approvedTx = transactionService.listApprovedTransactions(params);
+		for (Transaction t : approvedTx) {
+			LOG.debug("adding approved tx, which can be used for spending: {}", t);
+			copy2.put(t.getHash(), t);
+		}
+		return copy2;
+	}
 
-    public long balance(NetworkParameters params, Address p2shAddress) {
-        long balance = 0;
-        for (TransactionOutput transactionOutput : verifiedOutputs(params, p2shAddress)) {
-            balance += transactionOutput.getValue().value;
-        }
-        return balance;
-    }
+	@Transactional(readOnly = true)
+	public List<TransactionOutput> verifiedOutputs(NetworkParameters params, Address p2shAddress) {
+		List<TransactionOutput> retVal = new ArrayList<>();
 
-    @PreDestroy
-    public void shutdown() {
-        try {
-            if (peerGroup != null && peerGroup.isRunning()) {
-                LOG.info("stopping peer group...");
-                peerGroup.stop();
-                peerGroup = null;
-            }
-        } catch (Exception e) {
-            LOG.error("cannot stop peerGroup in shutdown", e);
-        }
-        try {
-            if (blockStore != null) {
-                LOG.info("closing block store...");
-                blockStore.close();
-                blockStore = null;
-            }
-        } catch (Exception e) {
-            LOG.error("cannot close blockStore in shutdown", e);
-        }
-        try {
-            if (wallet != null) {
-            	// TODO: the method name is misleading, it stops auto-save, but does not save.
-                LOG.info("shutdown wallet...");
-            	wallet.shutdownAutosaveAndWait();
-                wallet = null;
-            }
-        } catch (Exception e) {
-            LOG.error("cannot shutdown wallet in shutdown", e);
-        }
-    }
+		Map<Sha256Hash, Transaction> unspent = verifiedTransactions(params);
 
-    public PeerGroup peerGroup() {
-        return peerGroup;
-    }
+		for (Transaction t : unspent.values()) {
+			for (TransactionOutput out : t.getOutputs()) {
+				if (p2shAddress.equals(out.getAddressFromP2SH(appConfig.getNetworkParameters()))) {
+					if (out.isAvailableForSpending()) {
+						// now check if not spent
+						retVal.add(out);
+						LOG.debug("this txout is unspent : {}, point: {}, spent {}", out, out.getOutPointFor());
+					} else {
+						LOG.debug("this txout is spent!: {}, point: {}out.getOutPointFor()", out, out.getOutPointFor());
+					}
+				}
+			}
+		}
 
-    public Transaction receivePending(Transaction fullTx) {
-        wallet.receivePending(fullTx, null, false);
-        return wallet.getTransaction(fullTx.getHash());
-    }
+		return retVal;
+	}
 
-    public TransactionOutput findOutputFor(TransactionInput input) {
-        Transaction tx = wallet.getTransaction(input.getOutpoint().getHash());
-        if (tx == null) {
-            //TODO: useDB?
-            /*List<TransactionOutput> touts = wallet.getWatchedOutputs(true);
-            for(TransactionOutput to:touts) {
-                if(to.getOutPointFor().getHash().equals(input.getOutpoint().getHash()) &&
-                        to.getOutPointFor().getIndex() == input.getOutpoint().getIndex()) {
-                    LOG.debug("could not get TX from wallet, but we have it..." + to);
-                    return to;
-                }
-            }
-            LOG.debug("we only have the following tx hashes:");
-            for(TransactionOutput to:touts) {
-                LOG.debug("to:"+to.getOutPointFor().getHash()+":"+to.getOutPointFor().getIndex());
-            }*/
-            return null;
-        }
-        return tx.getOutput(input.getOutpoint().getIndex());
-    }
-    
-    public void broadcast(final Transaction fullTx) {
-        txQueueService.addTx(fullTx);
-        //broadcast immediately
-        final TransactionBroadcast broadcast = peerGroup().broadcastTransaction(fullTx);
-        Futures.addCallback(broadcast.future(), new FutureCallback<Transaction>() {
-            @Override
-            public void onSuccess(Transaction transaction) {
-                LOG.debug("broadcast success, transaction is out {}", fullTx.getHash());
-                txQueueService.removeTx(fullTx);
-            }
+	public long balance(NetworkParameters params, Address p2shAddress) {
+		long balance = 0;
+		for (TransactionOutput transactionOutput : verifiedOutputs(params, p2shAddress)) {
+			balance += transactionOutput.getValue().value;
+		}
+		return balance;
+	}
 
-            @Override
-            public void onFailure(Throwable throwable) {
-                LOG.error("broadcast failed, transaction is " + fullTx.getHash(), throwable);
-                try {
-                    //wait ten minutes
-                    Thread.sleep(10 * 60 * 1000);
-                    broadcast(fullTx);
-                } catch (InterruptedException ex) {
-                    LOG.debug("don't wait for tx {}", fullTx.getHash());
-                }
+	@PreDestroy
+	public void shutdown() {
+		try {
+			if (peerGroup != null && peerGroup.isRunning()) {
+				LOG.info("stopping peer group...");
+				peerGroup.stop();
+				peerGroup = null;
+			}
+		} catch (Exception e) {
+			LOG.error("cannot stop peerGroup in shutdown", e);
+		}
+		try {
+			if (blockStore != null) {
+				LOG.info("closing block store...");
+				blockStore.close();
+				blockStore = null;
+			}
+		} catch (Exception e) {
+			LOG.error("cannot close blockStore in shutdown", e);
+		}
+		try {
+			if (wallet != null) {
+				// TODO: the method name is misleading, it stops auto-save, but
+				// does not save.
+				LOG.info("shutdown wallet...");
+				wallet.shutdownAutosaveAndWait();
+				wallet = null;
+			}
+		} catch (Exception e) {
+			LOG.error("cannot shutdown wallet in shutdown", e);
+		}
+	}
 
-            }
-        });
+	public PeerGroup peerGroup() {
+		return peerGroup;
+	}
 
-    }
+	public Transaction receivePending(Transaction fullTx) {
+		wallet.receivePending(fullTx, null, false);
+		return wallet.getTransaction(fullTx.getHash());
+	}
 
-    private void pendingTransactions() {
-        final NetworkParameters params = appConfig.getNetworkParameters();
-        for(Transaction tx:txQueueService.all(params)) {
-            broadcast(tx);
-        }
-    }
+	public TransactionOutput findOutputFor(TransactionInput input) {
+		Transaction tx = wallet.getTransaction(input.getOutpoint().getHash());
+		if (tx == null) {
+			// TODO: useDB?
+			/*List<TransactionOutput> touts = wallet.getWatchedOutputs(true);
+			for(TransactionOutput to:touts) {
+				if(to.getOutPointFor().getHash().equals(input.getOutpoint().getHash()) &&
+						to.getOutPointFor().getIndex() == input.getOutpoint().getIndex()) {
+					LOG.debug("could not get TX from wallet, but we have it..." + to);
+					return to;
+				}
+			}
+			LOG.debug("we only have the following tx hashes:");
+			for(TransactionOutput to:touts) {
+				LOG.debug("to:"+to.getOutPointFor().getHash()+":"+to.getOutPointFor().getIndex());
+			}*/
+			return null;
+		}
+		return tx.getOutput(input.getOutpoint().getIndex());
+	}
+
+	public void broadcast(final Transaction fullTx) {
+		txQueueService.addTx(fullTx);
+		// broadcast immediately
+		final TransactionBroadcast broadcast = peerGroup().broadcastTransaction(fullTx);
+		Futures.addCallback(broadcast.future(), new FutureCallback<Transaction>() {
+			@Override
+			public void onSuccess(Transaction transaction) {
+				LOG.debug("broadcast success, transaction is out {}", fullTx.getHash());
+				txQueueService.removeTx(fullTx);
+			}
+
+			@Override
+			public void onFailure(Throwable throwable) {
+				LOG.error("broadcast failed, transaction is " + fullTx.getHash(), throwable);
+				try {
+					// wait ten minutes
+					Thread.sleep(10 * 60 * 1000);
+					broadcast(fullTx);
+				} catch (InterruptedException ex) {
+					LOG.debug("don't wait for tx {}", fullTx.getHash());
+				}
+
+			}
+		});
+
+	}
+
+	private void pendingTransactions() {
+		final NetworkParameters params = appConfig.getNetworkParameters();
+		for (Transaction tx : txQueueService.all(params)) {
+			broadcast(tx);
+		}
+	}
 
 	public Map<Address, Coin> getBalanceByAddresses() {
 		final NetworkParameters params = appConfig.getNetworkParameters();
-		
+
 		AddressCoinSelector selector = new AddressCoinSelector(null, params);
 		wallet.getBalance(selector);
-		
-		// getBalance considers UTXO: add zero balance for all watched scripts without unspent outputs
+
+		// getBalance considers UTXO: add zero balance for all watched scripts
+		// without unspent outputs
 		Map<Address, Coin> fullBalances = new HashMap<>(selector.getAddressBalances());
 		for (Script watched : getWatchedScripts()) {
 			Address address = watched.getToAddress(params);
@@ -455,7 +471,7 @@ public class WalletService {
 				fullBalances.put(address, Coin.ZERO);
 			}
 		}
-		
+
 		return fullBalances;
 	}
 
@@ -469,5 +485,5 @@ public class WalletService {
 
 	public List<TransactionOutput> getUnspentOutputs() {
 		return wallet.getUnspents();
-	}   
+	}
 }

--- a/src/main/java/com/coinblesk/server/utils/ApiVersion.java
+++ b/src/main/java/com/coinblesk/server/utils/ApiVersion.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
  *
  * @author Thomas Bocek
  */
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiVersion {
-    String[] value();
+	String[] value();
 }

--- a/src/main/java/com/coinblesk/server/utils/ApiVersionRequestMappingHandlerMapping.java
+++ b/src/main/java/com/coinblesk/server/utils/ApiVersionRequestMappingHandlerMapping.java
@@ -16,6 +16,7 @@
 package com.coinblesk.server.utils;
 
 import java.lang.reflect.Method;
+
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.servlet.mvc.condition.ConsumesRequestCondition;
 import org.springframework.web.servlet.mvc.condition.HeadersRequestCondition;
@@ -28,48 +29,50 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 /**
- * as in http://stackoverflow.com/questions/20198275/how-to-manage-rest-api-versioning-with-spring
+ * as in
+ * http://stackoverflow.com/questions/20198275/how-to-manage-rest-api-versioning-with-spring
+ *
  * @author Thomas Bocek
  */
 public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
-    
-    @Override
-    protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
-        RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
 
-        //no request mapping for this method
-        if(info == null) {
-            return null;
-        }
+	@Override
+	protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
+		RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
 
-        ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
-        if(methodAnnotation != null) {
-            RequestCondition<?> methodCondition = getCustomMethodCondition(method);
-            // Concatenate our ApiVersion with the usual request mapping
-            info = createApiVersionInfo(methodAnnotation, methodCondition).combine(info);
-        } else {
-            ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
-            if(typeAnnotation != null) {
-                RequestCondition<?> typeCondition = getCustomTypeCondition(handlerType);
-                // Concatenate our ApiVersion with the usual request mapping
-                info = createApiVersionInfo(typeAnnotation, typeCondition).combine(info);
-            }
-        }
+		// no request mapping for this method
+		if (info == null) {
+			return null;
+		}
 
-        return info;
-    }
+		ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
+		if (methodAnnotation != null) {
+			RequestCondition<?> methodCondition = getCustomMethodCondition(method);
+			// Concatenate our ApiVersion with the usual request mapping
+			info = createApiVersionInfo(methodAnnotation, methodCondition).combine(info);
+		} else {
+			ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
+			if (typeAnnotation != null) {
+				RequestCondition<?> typeCondition = getCustomTypeCondition(handlerType);
+				// Concatenate our ApiVersion with the usual request mapping
+				info = createApiVersionInfo(typeAnnotation, typeCondition).combine(info);
+			}
+		}
 
-    private RequestMappingInfo createApiVersionInfo(ApiVersion annotation, RequestCondition<?> customCondition) {
-        String[] values = annotation.value();
+		return info;
+	}
 
-        return new RequestMappingInfo(
-                new PatternsRequestCondition(values, getUrlPathHelper(), getPathMatcher(), useSuffixPatternMatch(), useTrailingSlashMatch(), getFileExtensions()),
-                new RequestMethodsRequestCondition(),
-                new ParamsRequestCondition(),
-                new HeadersRequestCondition(),
-                new ConsumesRequestCondition(),
-                new ProducesRequestCondition(),
-                customCondition);
-    }
+	private RequestMappingInfo createApiVersionInfo(ApiVersion annotation, RequestCondition<?> customCondition) {
+		String[] values = annotation.value();
+
+		return new RequestMappingInfo(
+				new PatternsRequestCondition(values, getUrlPathHelper(), getPathMatcher(), useSuffixPatternMatch(), useTrailingSlashMatch(), getFileExtensions()),
+				new RequestMethodsRequestCondition(),
+				new ParamsRequestCondition(),
+				new HeadersRequestCondition(),
+				new ConsumesRequestCondition(),
+				new ProducesRequestCondition(),
+				customCondition);
+	}
 
 }

--- a/src/main/java/com/coinblesk/server/utils/CoinUtils.java
+++ b/src/main/java/com/coinblesk/server/utils/CoinUtils.java
@@ -15,35 +15,36 @@
  */
 package com.coinblesk.server.utils;
 
-import com.coinblesk.bitcoin.BitcoinNet;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.params.UnitTestParams;
 
+import com.coinblesk.bitcoin.BitcoinNet;
+
 /**
  *
  * @author Thomas Bocek
  */
 public class CoinUtils {
-    /**
-     * 
-     * @param bitcoinNet
-     * @return the {@link NetworkParameters} for a specific network
-     */
-    public static NetworkParameters getNetworkParams(BitcoinNet bitcoinNet) {
-        switch (bitcoinNet) {
-        case UNITTEST:
-            return UnitTestParams.get();
-        case REGTEST:
-            return RegTestParams.get();
-        case TESTNET:
-            return TestNet3Params.get();
-        case MAINNET:
-            return MainNetParams.get();
-        default:
-            throw new RuntimeException("Please set the server property bitcoin.net to (unittest|regtest|testnet|main)");
-        }
-    }
+	/**
+	 *
+	 * @param bitcoinNet
+	 * @return the {@link NetworkParameters} for a specific network
+	 */
+	public static NetworkParameters getNetworkParams(BitcoinNet bitcoinNet) {
+		switch (bitcoinNet) {
+		case UNITTEST:
+			return UnitTestParams.get();
+		case REGTEST:
+			return RegTestParams.get();
+		case TESTNET:
+			return TestNet3Params.get();
+		case MAINNET:
+			return MainNetParams.get();
+		default:
+			throw new RuntimeException("Please set the server property bitcoin.net to (unittest|regtest|testnet|main)");
+		}
+	}
 }

--- a/src/main/java/com/coinblesk/server/utils/ToUtils.java
+++ b/src/main/java/com/coinblesk/server/utils/ToUtils.java
@@ -1,85 +1,84 @@
 package com.coinblesk.server.utils;
 
+import java.util.Calendar;
+import java.util.Date;
 
 import org.bitcoinj.core.ECKey;
 
 import com.coinblesk.json.v1.BaseTO;
 import com.coinblesk.json.v1.Type;
 import com.coinblesk.util.SerializeUtils;
-import java.util.Calendar;
-import java.util.Date;
 
 public final class ToUtils {
-	
+
 	private ToUtils() {
 		// prevent instances
 	}
-	
+
 	public static <K extends BaseTO> K newInstance(K k, Type returnType, ECKey signKey) {
-    	return newInstance(k.getClass(), returnType, signKey);
-    }
-    
-    public static <K extends BaseTO> K newInstance(Class<? extends BaseTO> clazz, Type returnType, ECKey signKey) {
-        K instance = newInstance(clazz, returnType);
-        if (instance == null) {
-        	return instance;
-        }
-        instance.publicKey(signKey.getPubKey());
-        SerializeUtils.signJSON(instance, signKey);
-        return instance;
-    }
-    
-    public static <K extends BaseTO> K newInstance(K k, Type returnType) {
-    	return newInstance(k.getClass(), returnType);
-    }
-    
-    public static <K extends BaseTO> K newInstance(Class<? extends BaseTO> clazz, Type returnType) {
-    	try {
-	    	BaseTO b = clazz.newInstance();
-	    	b.currentDate(System.currentTimeMillis());
-	        b.type(returnType);
-	        return (K) b;
-    	} catch (InstantiationException | IllegalAccessException ex) {
-            throw new RuntimeException("Cannot ceate instance", ex);
-        }
-    }
-    
-    public static <K extends BaseTO> K checkInput(final K input) {
-        return checkInput(input, true);
-    }
+		return newInstance(k.getClass(), returnType, signKey);
+	}
 
-    public static <K extends BaseTO> K checkInput(final K input, boolean checkDate) {
+	public static <K extends BaseTO> K newInstance(Class<? extends BaseTO> clazz, Type returnType, ECKey signKey) {
+		K instance = newInstance(clazz, returnType);
+		if (instance == null) {
+			return instance;
+		}
+		instance.publicKey(signKey.getPubKey());
+		SerializeUtils.signJSON(instance, signKey);
+		return instance;
+	}
 
-        if (!input.isInputSet()) {
-            return newInstance(input, Type.INPUT_MISMATCH);
-        }
+	public static <K extends BaseTO> K newInstance(K k, Type returnType) {
+		return newInstance(k.getClass(), returnType);
+	}
 
-        if(checkDate) {
-            //check if the client sent us a time which is way too old (1 day)
-            final Calendar fromClient = Calendar.getInstance();
-            fromClient.setTime(new Date(input.currentDate()));
+	public static <K extends BaseTO> K newInstance(Class<? extends BaseTO> clazz, Type returnType) {
+		try {
+			BaseTO b = clazz.newInstance();
+			b.currentDate(System.currentTimeMillis());
+			b.type(returnType);
+			return (K) b;
+		} catch (InstantiationException | IllegalAccessException ex) {
+			throw new RuntimeException("Cannot ceate instance", ex);
+		}
+	}
 
-            final Calendar fromServerDayBefore = Calendar.getInstance();
-            fromServerDayBefore.add(Calendar.DAY_OF_YEAR, -1);
+	public static <K extends BaseTO> K checkInput(final K input) {
+		return checkInput(input, true);
+	}
 
-            if (fromClient.before(fromServerDayBefore)) {
-                return newInstance(input, Type.TIME_MISMATCH);
-            }
+	public static <K extends BaseTO> K checkInput(final K input, boolean checkDate) {
 
-            final Calendar fromServerDayAfter = Calendar.getInstance();
-            fromServerDayAfter.add(Calendar.DAY_OF_YEAR, 1);
+		if (!input.isInputSet()) {
+			return newInstance(input, Type.INPUT_MISMATCH);
+		}
 
-            if (fromClient.after(fromServerDayAfter)) {
-                return newInstance(input, Type.TIME_MISMATCH);
-            }
-        }
+		if (checkDate) {
+			// check if the client sent us a time which is way too old (1 day)
+			final Calendar fromClient = Calendar.getInstance();
+			fromClient.setTime(new Date(input.currentDate()));
 
-        
-        if (!SerializeUtils.verifyJSONSignature(input, ECKey.fromPublicOnly(input.publicKey()))) {
-            return newInstance(input, Type.JSON_SIGNATURE_ERROR);
+			final Calendar fromServerDayBefore = Calendar.getInstance();
+			fromServerDayBefore.add(Calendar.DAY_OF_YEAR, -1);
 
-        }
-        return null;
-    }
-	
+			if (fromClient.before(fromServerDayBefore)) {
+				return newInstance(input, Type.TIME_MISMATCH);
+			}
+
+			final Calendar fromServerDayAfter = Calendar.getInstance();
+			fromServerDayAfter.add(Calendar.DAY_OF_YEAR, 1);
+
+			if (fromClient.after(fromServerDayAfter)) {
+				return newInstance(input, Type.TIME_MISMATCH);
+			}
+		}
+
+		if (!SerializeUtils.verifyJSONSignature(input, ECKey.fromPublicOnly(input.publicKey()))) {
+			return newInstance(input, Type.JSON_SIGNATURE_ERROR);
+
+		}
+		return null;
+	}
+
 }

--- a/src/test/java/com/coinblesk/server/controller/AuthTest.java
+++ b/src/test/java/com/coinblesk/server/controller/AuthTest.java
@@ -54,112 +54,130 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 
 public class AuthTest extends CoinbleskTest {
-    @Autowired
-    private WebApplicationContext webAppContext;
+	@Autowired
+	private WebApplicationContext webAppContext;
 
-    @Autowired
-    private UserAccountService userAccountService;
+	@Autowired
+	private UserAccountService userAccountService;
 
-    @MockBean
-    private MailService mailService;
+	@MockBean
+	private MailService mailService;
 
-    private static MockMvc mockMvc;
+	private static MockMvc mockMvc;
 
-    @Before
-    public void setUp() {
-         MockitoAnnotations.initMocks(this);
-         mockMvc = MockMvcBuilders
-                 .webAppContextSetup(webAppContext)
-                 .apply(springSecurity())
-                 .build();
-    }
-    
-    @Test
-    public void testCreateActivate() throws Exception {
-        mockMvc.perform(get("/v1/u/a/g")).andExpect(status().is4xxClientError());
-        UserAccountTO userAccountTO = new UserAccountTO();
-        MvcResult res = mockMvc.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(userAccountTO))).andExpect(status().isOk()).andReturn();
-        UserAccountStatusTO status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
-        Assert.assertEquals(Type.NO_EMAIL.nr(), status.type().nr());
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).apply(springSecurity()).build();
+	}
 
-        userAccountTO.email("test-test.test");
-        res = mockMvc.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(userAccountTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
-        Assert.assertEquals(Type.INVALID_EMAIL.nr(), status.type().nr());
+	@Test
+	public void testCreateActivate() throws Exception {
+		mockMvc.perform(get("/v1/u/a/g")).andExpect(status().is4xxClientError());
+		UserAccountTO userAccountTO = new UserAccountTO();
+		MvcResult res = mockMvc	.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON)
+								.content(SerializeUtils.GSON.toJson(userAccountTO)))
+								.andExpect(status().isOk())
+								.andReturn();
+		UserAccountStatusTO status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
+				UserAccountStatusTO.class);
+		Assert.assertEquals(Type.NO_EMAIL.nr(), status.type().nr());
 
-        userAccountTO.email("test@test.test");
-        res = mockMvc.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(userAccountTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
-        Assert.assertEquals(Type.PASSWORD_TOO_SHORT.nr(), status.type().nr());
+		userAccountTO.email("test-test.test");
+		res = mockMvc	.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON)
+						.content(SerializeUtils.GSON.toJson(userAccountTO)))
+						.andExpect(status().isOk())
+						.andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
+		Assert.assertEquals(Type.INVALID_EMAIL.nr(), status.type().nr());
 
-        userAccountTO.password("1234");
-        res = mockMvc.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(userAccountTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
-        Assert.assertEquals(Type.PASSWORD_TOO_SHORT.nr(), status.type().nr());
+		userAccountTO.email("test@test.test");
+		res = mockMvc	.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON)
+						.content(SerializeUtils.GSON.toJson(userAccountTO)))
+						.andExpect(status().isOk())
+						.andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
+		Assert.assertEquals(Type.PASSWORD_TOO_SHORT.nr(), status.type().nr());
 
-        userAccountTO.password("123456");
-        res = mockMvc.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(userAccountTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
-        Assert.assertTrue(status.isSuccess());
-        Mockito.verify(mailService, Mockito.times(1)).sendUserMail(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        Mockito.verify(mailService, Mockito.times(0)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
+		userAccountTO.password("1234");
+		res = mockMvc	.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON)
+						.content(SerializeUtils.GSON.toJson(userAccountTO)))
+						.andExpect(status().isOk())
+						.andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
+		Assert.assertEquals(Type.PASSWORD_TOO_SHORT.nr(), status.type().nr());
 
-        res = mockMvc.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(userAccountTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
-        Assert.assertEquals(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED.nr(), status.type().nr());
-        Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        Mockito.verify(mailService, Mockito.times(0)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
+		userAccountTO.password("123456");
+		res = mockMvc	.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON)
+						.content(SerializeUtils.GSON.toJson(userAccountTO)))
+						.andExpect(status().isOk())
+						.andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
+		Assert.assertTrue(status.isSuccess());
+		Mockito.verify(mailService, Mockito.times(1)).sendUserMail(Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString());
+		Mockito.verify(mailService, Mockito.times(0)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
 
-        //activate with wrong token sends admin an email
-        mockMvc.perform(get("/v1/u/v/test@test.test/blub")).andExpect(status().is5xxServerError());
-        Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
+		res = mockMvc	.perform(post("/v1/u/c").contentType(MediaType.APPLICATION_JSON)
+						.content(SerializeUtils.GSON.toJson(userAccountTO)))
+						.andExpect(status().isOk())
+						.andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
+		Assert.assertEquals(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED.nr(), status.type().nr());
+		Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString());
+		Mockito.verify(mailService, Mockito.times(0)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
 
-        //get correct token
-        String token = userAccountService.getToken("test@test.test");
-        Assert.assertNotNull(token);
-        mockMvc.perform(get("/v1/u/v/test@test.test/"+token)).andExpect(status().isOk());
-        Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
+		// activate with wrong token sends admin an email
+		mockMvc.perform(get("/v1/u/v/test@test.test/blub")).andExpect(status().is5xxServerError());
+		Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString());
+		Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
 
-        mockMvc.perform(get("/v1/u/a/g")).andExpect(status().is4xxClientError());
+		// get correct token
+		String token = userAccountService.getToken("test@test.test");
+		Assert.assertNotNull(token);
+		mockMvc.perform(get("/v1/u/v/test@test.test/" + token)).andExpect(status().isOk());
+		Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString());
+		Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
 
-        // Wrong password fails
-        mockMvc.perform(post("/user/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"username\":\"test@test.test\",\"password\":\"12345\"}")
-                )
-                .andExpect(status().is4xxClientError());
+		mockMvc.perform(get("/v1/u/a/g")).andExpect(status().is4xxClientError());
 
-        // Correct login returns a token
-        String authorizationToken = loginAndGetToken("test@test.test", "123456");
+		// Wrong password fails
+		mockMvc.perform(post("/user/login").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"username\":\"test@test.test\",\"password\":\"12345\"}"))
+				.andExpect(status().is4xxClientError());
 
-        // Token is valid
-        Assert.assertTrue(StringUtils.hasText(authorizationToken));
-        Assert.assertTrue(authorizationToken.startsWith("Bearer "));
-        String jwt = authorizationToken.substring(7, authorizationToken.length());
+		// Correct login returns a token
+		String authorizationToken = loginAndGetToken("test@test.test", "123456");
 
-        // Check claims
-        Jws<Claims> claims = Jwts.parser().setSigningKey("bitcoin".getBytes()).parseClaimsJws(jwt);
-        Assert.assertEquals(claims.getBody().getSubject(), "test@test.test");
-        Assert.assertTrue(claims.getBody().getExpiration().after(new Date()));
-        Assert.assertEquals(claims.getBody().get("auth", String.class), "ROLE_USER");
+		// Token is valid
+		Assert.assertTrue(StringUtils.hasText(authorizationToken));
+		Assert.assertTrue(authorizationToken.startsWith("Bearer "));
+		String jwt = authorizationToken.substring(7, authorizationToken.length());
 
-        // Get user profile with valid JWT
-        res = mockMvc.perform(get("/v1/u/a/g").header("Authorization", authorizationToken)).andExpect(status().isOk()).andReturn();
-        UserAccountTO uato = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountTO.class);
-        Assert.assertEquals("test@test.test", uato.email());
-    }
-    
-    private String loginAndGetToken(String username, String password) throws Exception {
-        return mockMvc.perform(post("/user/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"username\":\"test@test.test\",\"password\":\"123456\"}")
-                )
-                .andExpect(status().isOk())
-                .andExpect(header().string("Authorization", Matchers.not(Matchers.isEmptyOrNullString())))
-                .andReturn()
-                .getResponse()
-                .getHeader("Authorization");
-    }
+		// Check claims
+		Jws<Claims> claims = Jwts.parser().setSigningKey("bitcoin".getBytes()).parseClaimsJws(jwt);
+		Assert.assertEquals(claims.getBody().getSubject(), "test@test.test");
+		Assert.assertTrue(claims.getBody().getExpiration().after(new Date()));
+		Assert.assertEquals(claims.getBody().get("auth", String.class), "ROLE_USER");
+
+		// Get user profile with valid JWT
+		res = mockMvc	.perform(get("/v1/u/a/g").header("Authorization", authorizationToken))
+						.andExpect(status().isOk())
+						.andReturn();
+		UserAccountTO uato = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountTO.class);
+		Assert.assertEquals("test@test.test", uato.email());
+	}
+
+	private String loginAndGetToken(String username, String password) throws Exception {
+		return mockMvc.perform(post("/user/login").contentType(MediaType.APPLICATION_JSON).content(
+				"{\"username\":\"test@test.test\",\"password\":\"123456\"}"))
+						.andExpect(status().isOk())
+						.andExpect(header().string("Authorization", Matchers.not(Matchers.isEmptyOrNullString())))
+						.andReturn()
+						.getResponse()
+						.getHeader("Authorization");
+	}
 }

--- a/src/test/java/com/coinblesk/server/controller/AuthTest.java
+++ b/src/test/java/com/coinblesk/server/controller/AuthTest.java
@@ -77,53 +77,59 @@ public class AuthTest extends CoinbleskTest {
 	public void testCreateActivate() throws Exception {
 		mockMvc.perform(get("/v1/user/auth/get")).andExpect(status().is4xxClientError());
 		UserAccountTO userAccountTO = new UserAccountTO();
-		MvcResult res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
-								.content(SerializeUtils.GSON.toJson(userAccountTO)))
-								.andExpect(status().isOk())
-								.andReturn();
+		MvcResult res = mockMvc
+				.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(userAccountTO)))
+				.andExpect(status().isOk())
+				.andReturn();
 		UserAccountStatusTO status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
 				UserAccountStatusTO.class);
 		Assert.assertEquals(Type.NO_EMAIL.nr(), status.type().nr());
 
 		userAccountTO.email("test-test.test");
-		res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
-						.content(SerializeUtils.GSON.toJson(userAccountTO)))
-						.andExpect(status().isOk())
-						.andReturn();
+		res = mockMvc
+				.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(userAccountTO)))
+				.andExpect(status().isOk())
+				.andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
 		Assert.assertEquals(Type.INVALID_EMAIL.nr(), status.type().nr());
 
 		userAccountTO.email("test@test.test");
-		res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
-						.content(SerializeUtils.GSON.toJson(userAccountTO)))
-						.andExpect(status().isOk())
-						.andReturn();
+		res = mockMvc
+				.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(userAccountTO)))
+				.andExpect(status().isOk())
+				.andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
 		Assert.assertEquals(Type.PASSWORD_TOO_SHORT.nr(), status.type().nr());
 
 		userAccountTO.password("1234");
-		res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
-						.content(SerializeUtils.GSON.toJson(userAccountTO)))
-						.andExpect(status().isOk())
-						.andReturn();
+		res = mockMvc
+				.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(userAccountTO)))
+				.andExpect(status().isOk())
+				.andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
 		Assert.assertEquals(Type.PASSWORD_TOO_SHORT.nr(), status.type().nr());
 
 		userAccountTO.password("123456");
-		res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
-						.content(SerializeUtils.GSON.toJson(userAccountTO)))
-						.andExpect(status().isOk())
-						.andReturn();
+		res = mockMvc
+				.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(userAccountTO)))
+				.andExpect(status().isOk())
+				.andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
 		Assert.assertTrue(status.isSuccess());
 		Mockito.verify(mailService, Mockito.times(1)).sendUserMail(Mockito.anyString(), Mockito.anyString(),
 				Mockito.anyString());
 		Mockito.verify(mailService, Mockito.times(0)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
 
-		res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
-						.content(SerializeUtils.GSON.toJson(userAccountTO)))
-						.andExpect(status().isOk())
-						.andReturn();
+		res = mockMvc
+				.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(userAccountTO)))
+				.andExpect(status().isOk())
+				.andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountStatusTO.class);
 		Assert.assertEquals(Type.SUCCESS_BUT_EMAIL_ALREADY_EXISTS_NOT_ACTIVATED.nr(), status.type().nr());
 		Mockito.verify(mailService, Mockito.times(2)).sendUserMail(Mockito.anyString(), Mockito.anyString(),
@@ -166,20 +172,24 @@ public class AuthTest extends CoinbleskTest {
 		Assert.assertEquals(claims.getBody().get("auth", String.class), "ROLE_USER");
 
 		// Get user profile with valid JWT
-		res = mockMvc	.perform(get("/v1/user/auth/get").header("Authorization", authorizationToken))
-						.andExpect(status().isOk())
-						.andReturn();
+		res = mockMvc
+				.perform(get("/v1/user/auth/get").header("Authorization", authorizationToken))
+				.andExpect(status().isOk())
+				.andReturn();
 		UserAccountTO uato = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountTO.class);
 		Assert.assertEquals("test@test.test", uato.email());
 	}
 
 	private String loginAndGetToken(String username, String password) throws Exception {
-		return mockMvc.perform(post("/user/login").contentType(MediaType.APPLICATION_JSON).content(
-				"{\"username\":\"test@test.test\",\"password\":\"123456\"}"))
-						.andExpect(status().isOk())
-						.andExpect(header().string("Authorization", Matchers.not(Matchers.isEmptyOrNullString())))
-						.andReturn()
-						.getResponse()
-						.getHeader("Authorization");
+		return mockMvc
+				.perform(
+						post("/user/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"username\":\"test@test.test\",\"password\":\"123456\"}"))
+				.andExpect(status().isOk())
+				.andExpect(header().string("Authorization", Matchers.not(Matchers.isEmptyOrNullString())))
+				.andReturn()
+				.getResponse()
+				.getHeader("Authorization");
 	}
 }

--- a/src/test/java/com/coinblesk/server/controller/AuthTest.java
+++ b/src/test/java/com/coinblesk/server/controller/AuthTest.java
@@ -75,7 +75,7 @@ public class AuthTest extends CoinbleskTest {
 
 	@Test
 	public void testCreateActivate() throws Exception {
-		mockMvc.perform(get("/v1/u/a/g")).andExpect(status().is4xxClientError());
+		mockMvc.perform(get("/v1/user/auth/get")).andExpect(status().is4xxClientError());
 		UserAccountTO userAccountTO = new UserAccountTO();
 		MvcResult res = mockMvc	.perform(post("/v1/user/create").contentType(MediaType.APPLICATION_JSON)
 								.content(SerializeUtils.GSON.toJson(userAccountTO)))
@@ -144,7 +144,7 @@ public class AuthTest extends CoinbleskTest {
 				Mockito.anyString());
 		Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
 
-		mockMvc.perform(get("/v1/u/a/g")).andExpect(status().is4xxClientError());
+		mockMvc.perform(get("/v1/user/auth/get")).andExpect(status().is4xxClientError());
 
 		// Wrong password fails
 		mockMvc.perform(post("/user/login").contentType(MediaType.APPLICATION_JSON)
@@ -166,7 +166,7 @@ public class AuthTest extends CoinbleskTest {
 		Assert.assertEquals(claims.getBody().get("auth", String.class), "ROLE_USER");
 
 		// Get user profile with valid JWT
-		res = mockMvc	.perform(get("/v1/u/a/g").header("Authorization", authorizationToken))
+		res = mockMvc	.perform(get("/v1/user/auth/get").header("Authorization", authorizationToken))
 						.andExpect(status().isOk())
 						.andReturn();
 		UserAccountTO uato = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), UserAccountTO.class);

--- a/src/test/java/com/coinblesk/server/controller/CompleteCLTVTest.java
+++ b/src/test/java/com/coinblesk/server/controller/CompleteCLTVTest.java
@@ -50,58 +50,54 @@ import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 public class CompleteCLTVTest extends CoinbleskTest {
-	
+
 	private static final Logger Log = LoggerFactory.getLogger(CompleteCLTVTest.class);
-	
+
 	@Rule
-    public ExpectedException thrown = ExpectedException.none();
-	
+	public ExpectedException thrown = ExpectedException.none();
+
 	private final String TEST_WALLET_PREFIX = "test-wallet";
-	
-    @Autowired
-    private WebApplicationContext webAppContext;
 
-    private MockMvc mockMvc;
-    
-    @Autowired
-    private AppConfig appConfig;
-    private NetworkParameters params;
-    private File tempDir;
-    
-    @Autowired
-    private WalletService walletService;
-    
-    @Autowired
-    private KeyService keyService;
-    
-    private Client client;
-    private Client merchant;
+	@Autowired
+	private WebApplicationContext webAppContext;
 
-    
-    @Before
-    public void setUp() throws Exception {
-    	tempDir = Files.createTempDir();
-    	
-        walletService.shutdown();
-        mockMvc = MockMvcBuilders
-                .webAppContextSetup(webAppContext)
-                .build();
-        
-        params = appConfig.getNetworkParameters();
-        walletService.init();
-        client = new Client(appConfig.getNetworkParameters(), mockMvc);
-        merchant = new Client(appConfig.getNetworkParameters(), mockMvc);
-        client.initWallet(tempDir, TEST_WALLET_PREFIX + "_client");
-        
-        fundClient(client.getChangeAddress());
-    }
+	private MockMvc mockMvc;
 
-    @After
-    public void tearDown() {
-    	client.shutdownWallet();
-    	
+	@Autowired
+	private AppConfig appConfig;
+	private NetworkParameters params;
+	private File tempDir;
+
+	@Autowired
+	private WalletService walletService;
+
+	@Autowired
+	private KeyService keyService;
+
+	private Client client;
+	private Client merchant;
+
+	@Before
+	public void setUp() throws Exception {
+		tempDir = Files.createTempDir();
+
+		walletService.shutdown();
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+
+		params = appConfig.getNetworkParameters();
+		walletService.init();
+		client = new Client(appConfig.getNetworkParameters(), mockMvc);
+		merchant = new Client(appConfig.getNetworkParameters(), mockMvc);
+		client.initWallet(tempDir, TEST_WALLET_PREFIX + "_client");
+
+		fundClient(client.getChangeAddress());
+	}
+
+	@After
+	public void tearDown() {
+		client.shutdownWallet();
+
 		File[] walletFiles = tempDir.listFiles(new FilenameFilter() {
 			@Override
 			public boolean accept(File dir, String name) {
@@ -112,453 +108,447 @@ public class CompleteCLTVTest extends CoinbleskTest {
 			wf.delete();
 		}
 		tempDir.delete();
-    }
-    
-    @Test
-	@DatabaseSetup("/EmptyDatabase.xml")
-	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testReceiveFunds() throws Exception {
-    	Transaction tx = fundClient(client.getChangeAddress());
-    	
-    	Map<Sha256Hash, Transaction> txUnspent;
-    	
-    	txUnspent = walletService.verifiedTransactions(params);
-    	assertTrue(txUnspent.containsKey(tx.getHash()));
-    	
-    	txUnspent = client.wallet().getTransactionPool(Pool.UNSPENT);
-    	assertTrue(txUnspent.containsKey(tx.getHash()));
-    }
-    
-    @Test
-	@DatabaseSetup("/EmptyDatabase.xml")
-	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* provide 2 signatures -> spending should succeed */
-    public void testSpend_BeforeLockTimeExpiry() throws Exception {
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
-    	
-    	
-    	
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	assertTrue(clientSigs.size() > 0);
-    	
-    	SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
-    	assertNotNull(signTO);
-    	assertTrue(signTO.isSuccess());
-    	List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
-    	assertTrue(serverSigs.size() > 0);
-    	assertEquals(serverSigs.size(), tx.getInputs().size());
-    	
-    	
-    	assertEquals(clientSigs.size(), serverSigs.size());
-    	
-    	client.applySignatures(tx, clientSigs, serverSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
-    
-    @Test
-	@DatabaseSetup("/EmptyDatabase.xml")
-	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* provide 2 signatures, but in reversed order, should fail */
-    public void testSpend_BeforeLockTimeExpiry_ReversedSignatures() throws Exception {
-    	thrown.expect(ScriptException.class);
-    	thrown.expectMessage("Script failed OP_CHECKSIGVERIFY"); // checksigverify is used for the server sig (before client)
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
-    	
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
-    	List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
-    	
-    	assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size() && clientSigs.size() == serverSigs.size());
-    	
-    	// Note: reversed signature lists
-    	client.applySignatures(tx, serverSigs, clientSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
-    
-    @Test
-	@DatabaseSetup("/EmptyDatabase.xml")
-	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* spending with single sig of client is possible if locktime and seqNr is set properly */
-    public void testSpend_AfterLockTimeExpiry_SingleSig() throws Exception {
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
-    	
-    	TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(client.getAllAddresses().get(client.getChangeAddress()));
-    	tx.setLockTime(address.getLockTime());
-    	tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+	}
 
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
-    	
-    	// provide only single sig.
-    	client.applySignatures(tx, clientSigs);
-    	client.verifyTx(tx);
-
-    	fakeBroadcast(tx);
-    }
-    
-    @Test
+	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* spending with single sig of server should not be possible */
-    public void testSpend_AfterLockTimeExpiry_SingleServerSig() throws Exception {
-    	thrown.expect(ScriptException.class);
-    	/* last checksig operation will fail and push false onto the stack */
-    	thrown.expectMessage("P2SH script execution resulted in a non-true stack"); 
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
-    	
-    	TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(client.getAllAddresses().get(client.getChangeAddress()));
-    	tx.setLockTime(address.getLockTime());
-    	tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+	public void testReceiveFunds() throws Exception {
+		Transaction tx = fundClient(client.getChangeAddress());
 
-    	// we must send signatures to server in order to sign.
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
-    	List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
-    	assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == serverSigs.size());
-    	
-    	// provide only single sig, but not from client!
-    	client.applySignatures(tx, serverSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
-    
-    @Test
+		Map<Sha256Hash, Transaction> txUnspent;
+
+		txUnspent = walletService.verifiedTransactions(params);
+		assertTrue(txUnspent.containsKey(tx.getHash()));
+
+		txUnspent = client.wallet().getTransactionPool(Pool.UNSPENT);
+		assertTrue(txUnspent.containsKey(tx.getHash()));
+	}
+
+	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-	/* spending with single sig of client fails without lockTime */
-	public void testSpend_AfterLockTimeExpiry_SingleSig_LockTimeTooSmall() throws Exception {
-		thrown.expect(ScriptException.class);
-		thrown.expectMessage("Locktime requirement not satisfied"); /* tx lock time does not match CLTV argument */
-		
+	/* provide 2 signatures -> spending should succeed */
+	public void testSpend_BeforeLockTimeExpiry() throws Exception {
 		Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
-		
-		TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(client.getAllAddresses().get(client.getChangeAddress()));
-		tx.setLockTime(address.getLockTime() - 1);
-		tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
-	
+				params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.divide(2).value);
+
 		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
-		
-		// provide only single sig.
-		client.applySignatures(tx, clientSigs);
+		assertTrue(clientSigs.size() > 0);
+
+		SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
+		assertNotNull(signTO);
+		assertTrue(signTO.isSuccess());
+		List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
+		assertTrue(serverSigs.size() > 0);
+		assertEquals(serverSigs.size(), tx.getInputs().size());
+
+		assertEquals(clientSigs.size(), serverSigs.size());
+
+		client.applySignatures(tx, clientSigs, serverSigs);
 		client.verifyTx(tx);
-		
+
 		fakeBroadcast(tx);
 	}
 
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* spending with single sig of client fails without lockTime */
-    public void testSpend_AfterLockTimeExpiry_SingleSig_MissingLockTime() throws Exception {
-    	thrown.expect(ScriptException.class);
-    	thrown.expectMessage("Locktime requirement type mismatch"); /* tx lock time is 0 ("blockheight"), but provided is a  lock time in seconds */
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
-    	
-    	// nLockTime of Tx not set!
-    	tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+	/* provide 2 signatures, but in reversed order, should fail */
+	public void testSpend_BeforeLockTimeExpiry_ReversedSignatures() throws Exception {
+		thrown.expect(ScriptException.class);
+		// checksigverify is used for the server sig (before client)
+		thrown.expectMessage("Script failed OP_CHECKSIGVERIFY"); 
 
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
-    	
-    	// provide only single sig.
-    	client.applySignatures(tx, clientSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
-    
-    @Test
-	@DatabaseSetup("/EmptyDatabase.xml")
-	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* spending with single sig of client fails without seqNr */
-    public void testSpend_AfterLockTimeExpiry_SingleSig_MissingSeqNr() throws Exception {
-    	thrown.expect(ScriptException.class);
-    	thrown.expectMessage("Transaction contains a final transaction input for a CHECKLOCKTIMEVERIFY script.");
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
+		Transaction tx = BitcoinUtils.createTx(
+				params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.divide(2).value);
 
-    	
-    	TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(client.getAllAddresses().get(client.getChangeAddress()));
-    	tx.setLockTime(address.getLockTime());
-    	// seqNr not set!
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
+		List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
 
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
-    	
-    	// provide only single sig.
-    	client.applySignatures(tx, clientSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
-    
-    @Test
-	@DatabaseSetup("/EmptyDatabase.xml")
-	@DatabaseTearDown("/EmptyDatabase.xml")
-    /* spending with single sig of client fails without seqNr */
-    public void testSpend_AfterLockTimeExpiry_SingleSig_MissingSeqNrAndLockTime() throws Exception {
-    	thrown.expect(ScriptException.class);
-    	thrown.expectMessage("Locktime requirement type mismatch"); /* we have set a lockTime in seconds, lockTime 0 is "blockheight" */
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.divide(2).value);
+		assertTrue(tx.getInputs().size() > 0
+				&& tx.getInputs().size() == clientSigs.size()
+				&& clientSigs.size() == serverSigs.size());
 
-    	// nLockTime not set!
-    	// seqNr not set!
+		// Note: reversed signature lists
+		client.applySignatures(tx, serverSigs, clientSigs);
+		client.verifyTx(tx);
 
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
-    	
-    	// provide only single sig.
-    	client.applySignatures(tx, clientSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
+		fakeBroadcast(tx);
+	}
 
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testSpend_BeforeLockTime_MultipleInputs() throws Exception {
-    	for (int i = 0; i < 5; ++i) {
-    		client.createTimeLockedAddress();
-    		fundClient(client.getChangeAddress());
-    	}
-    	
-    	for (Map.Entry<Address, Coin> b : client.getBalanceByAddresses().entrySet()) {
-    		Log.info("Address balance: {}", b.getValue().toFriendlyString());
-    	}
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			client.wallet().getUnspents(), 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.multiply(3).value);
-    	
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
-        Assert.assertTrue(signTO.isSuccess());
-    	List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
-    	
-    	assertEquals(clientSigs.size(), serverSigs.size());
-    	client.applySignatures(tx, clientSigs, serverSigs);
-    	client.verifyTx(tx);
-    	
-    	fakeBroadcast(tx);
-    }
-	
+	/*
+	 * spending with single sig of client is possible if locktime and seqNr is
+	 * set properly
+	 */
+	public void testSpend_AfterLockTimeExpiry_SingleSig() throws Exception {
+		Transaction tx = BitcoinUtils.createTx(params, client.wallet().getUnspents(), client.getAllAddresses().keySet(),
+				client.getChangeAddress(), merchant.getChangeAddress(), Coin.COIN.divide(2).value);
+
+		TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(
+				client.getAllAddresses().get(client.getChangeAddress()));
+		tx.setLockTime(address.getLockTime());
+		tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
+
+		// provide only single sig.
+		client.applySignatures(tx, clientSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testSpend_BeforeLockTime_DoubleSpend() throws Exception {
+	/* spending with single sig of server should not be possible */
+	public void testSpend_AfterLockTimeExpiry_SingleServerSig() throws Exception {
+		thrown.expect(ScriptException.class);
+		/* last checksig operation will fail and push false onto the stack */
+		thrown.expectMessage("P2SH script execution resulted in a non-true stack");
+
+		Transaction tx = BitcoinUtils.createTx(params, client.wallet().getUnspents(), client.getAllAddresses().keySet(),
+				client.getChangeAddress(), merchant.getChangeAddress(), Coin.COIN.divide(2).value);
+
+		TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(
+				client.getAllAddresses().get(client.getChangeAddress()));
+		tx.setLockTime(address.getLockTime());
+		tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+
+		// we must send signatures to server in order to sign.
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
+		List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
+		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == serverSigs.size());
+
+		// provide only single sig, but not from client!
+		client.applySignatures(tx, serverSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	/* spending with single sig of client fails without lockTime */
+	public void testSpend_AfterLockTimeExpiry_SingleSig_LockTimeTooSmall() throws Exception {
+		thrown.expect(ScriptException.class);
+		/* tx lock time does not match CLTV argument */
+		thrown.expectMessage("Locktime requirement not satisfied");
+
+		Transaction tx = BitcoinUtils.createTx(
+				params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.divide(2).value);
+
+		TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(
+				client.getAllAddresses().get(client.getChangeAddress()));
+		tx.setLockTime(address.getLockTime() - 1);
+		tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
+
+		// provide only single sig.
+		client.applySignatures(tx, clientSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	/* spending with single sig of client fails without lockTime */
+	public void testSpend_AfterLockTimeExpiry_SingleSig_MissingLockTime() throws Exception {
+		thrown.expect(ScriptException.class);
+		/* tx lock time is 0 ("blockheight"), but provided is a lock time in seconds */
+		thrown.expectMessage("Locktime requirement type mismatch");
+
+		Transaction tx = BitcoinUtils.createTx(
+				params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.divide(2).value);
+
+		// nLockTime of Tx not set!
+		tx.getInputs().forEach(ti -> ti.setSequenceNumber(0));
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
+
+		// provide only single sig.
+		client.applySignatures(tx, clientSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	/* spending with single sig of client fails without seqNr */
+	public void testSpend_AfterLockTimeExpiry_SingleSig_MissingSeqNr() throws Exception {
+		thrown.expect(ScriptException.class);
+		thrown.expectMessage("Transaction contains a final transaction input for a CHECKLOCKTIMEVERIFY script.");
+
+		Transaction tx = BitcoinUtils.createTx(params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.divide(2).value);
+
+		TimeLockedAddress address = TimeLockedAddress.fromRedeemScript(
+				client.getAllAddresses().get(client.getChangeAddress()));
+		tx.setLockTime(address.getLockTime());
+		// seqNr not set!
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
+
+		// provide only single sig.
+		client.applySignatures(tx, clientSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	/* spending with single sig of client fails without seqNr */
+	public void testSpend_AfterLockTimeExpiry_SingleSig_MissingSeqNrAndLockTime() throws Exception {
+		thrown.expect(ScriptException.class);
+		/* we have set a lockTime in seconds, lockTime 0 is "blockheight" */
+		thrown.expectMessage("Locktime requirement type mismatch");
+
+		Transaction tx = BitcoinUtils.createTx(
+				params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.divide(2).value);
+
+		// nLockTime not set!
+		// seqNr not set!
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		assertTrue(tx.getInputs().size() > 0 && tx.getInputs().size() == clientSigs.size());
+
+		// provide only single sig.
+		client.applySignatures(tx, clientSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testSpend_BeforeLockTime_MultipleInputs() throws Exception {
+		for (int i = 0; i < 5; ++i) {
+			client.createTimeLockedAddress();
+			fundClient(client.getChangeAddress());
+		}
+
+		for (Map.Entry<Address, Coin> b : client.getBalanceByAddresses().entrySet()) {
+			Log.info("Address balance: {}", b.getValue().toFriendlyString());
+		}
+
+		Transaction tx = BitcoinUtils.createTx(
+				params,
+				client.wallet().getUnspents(),
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.multiply(3).value);
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
+		Assert.assertTrue(signTO.isSuccess());
+		List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
+
+		assertEquals(clientSigs.size(), serverSigs.size());
+		client.applySignatures(tx, clientSigs, serverSigs);
+		client.verifyTx(tx);
+
+		fakeBroadcast(tx);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testSpend_BeforeLockTime_DoubleSpend() throws Exception {
 		List<Transaction> clientTx = new ArrayList<>();
-    	for (int i = 0; i < 2; ++i) {
-    		client.createTimeLockedAddress();
-    		Transaction tx = fundClient(client.getChangeAddress());
-    		clientTx.add(tx);
-    	}
-    	   	
-    	List<TransactionOutput> utxo = new ArrayList<>(client.wallet().getUnspents());
-    	List<TransactionOutput> utxoToSpend = new ArrayList<>(utxo);
-    	utxoToSpend.remove(0);
-    	
-    	Transaction tx = BitcoinUtils.createTx(
-						    			params, 
-						    			utxoToSpend, 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.div(3).value);
-    	
-    	List<TransactionSignature> clientSigs = client.signTxByClient(tx);
-    	SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
-    	List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
-    	
-    	assertEquals(clientSigs.size(), serverSigs.size());
-    	client.applySignatures(tx, clientSigs, serverSigs);
-    	client.verifyTx(tx);
-    	 	
-    	//// 2. Double spend
-    	Transaction txDouble = BitcoinUtils.createTx(
-						    			params, 
-						    			utxoToSpend, 
-						    			client.getAllAddresses().keySet(), 
-						    			client.getChangeAddress(), 
-						    			merchant.getChangeAddress(), 
-						    			Coin.COIN.div(4).value);
-    	
-    	List<TransactionSignature> clientSigsDouble = client.signTxByClient(txDouble);
-    	SignVerifyTO signTODouble = client.signTxByServer(
-    			FakeTxBuilder.roundTripTransaction(params, txDouble), clientSigsDouble);
-    	assertFalse(signTODouble.isSuccess());
-    	assertEquals(signTODouble.type(), Type.BURNED_OUTPUTS);
-    	assertNull(signTODouble.transaction());
-    	assertNull(signTODouble.signatures());
-    }
-	
-	
-	
-    /*******************************
-     * 
-     * BLOCKCHAIN implementation
-     * 
-     *******************************/
-	
-    private Transaction fundClient(Address addressTo) throws Exception {
-    	Transaction tx = sendFakeCoins(params, Coin.COIN, addressTo);
-    	assertNotNull(tx);
-    	return tx;
-    }
-	
-    private Transaction sendFakeCoins(NetworkParameters params, Coin amount, Address to) throws Exception {
-        Transaction tx = FakeTxBuilder.createFakeTx(params, amount, to);
-        fakeBroadcast(tx);
-        return tx;
-    }
-    
-    private void fakeBroadcast(Transaction tx) throws Exception {
-    	fakeBroadcast(tx, walletService.blockChain(), client.blockChain(), merchant.blockChain());
-    }
-    
-    private static void fakeBroadcast(Transaction tx, BlockChain... blockChain) throws Exception {
-    	// tx is serialized for each blockChain such because adding to chain and wallet alters flags and pointers.
-    	final NetworkParameters params = tx.getParams();
-    	final byte[] serializedTx = tx.bitcoinSerialize();
+		for (int i = 0; i < 2; ++i) {
+			client.createTimeLockedAddress();
+			Transaction tx = fundClient(client.getChangeAddress());
+			clientTx.add(tx);
+		}
+
+		List<TransactionOutput> utxo = new ArrayList<>(client.wallet().getUnspents());
+		List<TransactionOutput> utxoToSpend = new ArrayList<>(utxo);
+		utxoToSpend.remove(0);
+
+		Transaction tx = BitcoinUtils.createTx(
+				params,
+				utxoToSpend,
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.div(3).value);
+
+		List<TransactionSignature> clientSigs = client.signTxByClient(tx);
+		SignVerifyTO signTO = client.signTxByServer(tx, clientSigs);
+		List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(signTO.signatures());
+
+		assertEquals(clientSigs.size(), serverSigs.size());
+		client.applySignatures(tx, clientSigs, serverSigs);
+		client.verifyTx(tx);
+
+		//// 2. Double spend
+		Transaction txDouble = BitcoinUtils.createTx(
+				params,
+				utxoToSpend,
+				client.getAllAddresses().keySet(),
+				client.getChangeAddress(),
+				merchant.getChangeAddress(),
+				Coin.COIN.div(4).value);
+
+		List<TransactionSignature> clientSigsDouble = client.signTxByClient(txDouble);
+		SignVerifyTO signTODouble = client.signTxByServer(FakeTxBuilder.roundTripTransaction(params, txDouble),
+				clientSigsDouble);
+		assertFalse(signTODouble.isSuccess());
+		assertEquals(signTODouble.type(), Type.BURNED_OUTPUTS);
+		assertNull(signTODouble.transaction());
+		assertNull(signTODouble.signatures());
+	}
+
+	/*******************************
+	 * 
+	 * BLOCKCHAIN implementation
+	 * 
+	 *******************************/
+
+	private Transaction fundClient(Address addressTo) throws Exception {
+		Transaction tx = sendFakeCoins(params, Coin.COIN, addressTo);
+		assertNotNull(tx);
+		return tx;
+	}
+
+	private Transaction sendFakeCoins(NetworkParameters params, Coin amount, Address to) throws Exception {
+		Transaction tx = FakeTxBuilder.createFakeTx(params, amount, to);
+		fakeBroadcast(tx);
+		return tx;
+	}
+
+	private void fakeBroadcast(Transaction tx) throws Exception {
+		fakeBroadcast(tx, walletService.blockChain(), client.blockChain(), merchant.blockChain());
+	}
+
+	private static void fakeBroadcast(Transaction tx, BlockChain... blockChain) throws Exception {
+		// tx is serialized for each blockChain such because adding to chain and
+		// wallet alters flags and pointers.
+		final NetworkParameters params = tx.getParams();
+		final byte[] serializedTx = tx.bitcoinSerialize();
 		for (BlockChain chain : blockChain) {
 			if (chain == null) {
 				continue;
 			}
-			
+
 			Block blockHead = chain.getBlockStore().getChainHead().getHeader();
 			Transaction txCopy = new Transaction(params, serializedTx);
 			Block block = FakeTxBuilder.makeSolvedTestBlock(blockHead, txCopy);
 			chain.add(block);
 		}
 	}
-    
-    
-    /**
-     * TODO Testcases
-     * - double spend
-     * - instant test: 
-     * (1) before/after time lock (one and multiple inputs)
-     * (2) parent not instant / instant 
-     * (3) by confidence
-     */
 
-    
-    
-    /*******************************
-     * 
-     * CLIENT implementation
-     * 
-     *******************************/
-	
+	/**
+	 * TODO Testcases
+	 * - double spend
+	 * - instant test:
+	 * (1) before/after time lock (one and multiple inputs)
+	 * (2) parent not instant / instant
+	 * (3) by confidence
+	 */
+
+	/*******************************
+	 * 
+	 * CLIENT implementation
+	 * 
+	 *******************************/
+
 	private static class Client {
 		private final ECKey clientKey, serverKey;
-		
+
 		private Map<Address, byte[]> addressesToRedeemScripts;
 		private Address mostRecentAddress;
-		
+
 		private final NetworkParameters params;
 		private MockMvc mockMvc;
-		
+
 		private WalletAppKit clientAppKit;
-		
+
 		public Client(NetworkParameters params, MockMvc mockMvc) throws Exception {
 			this.params = params;
 			this.mockMvc = mockMvc;
 			this.clientKey = new ECKey();
 			this.addressesToRedeemScripts = new HashMap<>();
 			this.serverKey = keyExchange();
-			
+
 			TimeLockedAddress timeLockedAddress = createTimeLockedAddress();
-			
+
 		}
 
 		public Map<Address, Coin> getBalanceByAddresses() {
 			// this is not really efficient, we could it do in 1 iteration!
 			Map<Address, Coin> balance = new HashMap<>();
-	    	for (Address addr : getAllAddresses().keySet()) {
-	    		Coin addressBalance = wallet().getBalance(new AddressCoinSelector(addr, params));
-	    		balance.put(addr, addressBalance);
-	    	}
-	    	return balance;
+			for (Address addr : getAllAddresses().keySet()) {
+				Coin addressBalance = wallet().getBalance(new AddressCoinSelector(addr, params));
+				balance.put(addr, addressBalance);
+			}
+			return balance;
 		}
-		
+
 		public void applySignatures(Transaction tx, List<TransactionSignature> clientSigs,
-													List<TransactionSignature> serverSigs) {
+				List<TransactionSignature> serverSigs) {
 			// apply
-	    	for (int tiIndex = 0; tiIndex < tx.getInputs().size(); ++tiIndex) {
-	    		TransactionInput ti = tx.getInput(tiIndex);
-	    		TransactionSignature clientSig = clientSigs.get(tiIndex);
-	    		TransactionSignature serverSig = serverSigs.get(tiIndex);
-	    		
-	    		Address outputAddr = ti.getConnectedOutput().getAddressFromP2SH(params);
-	    		byte[] redeemScript = addressesToRedeemScripts.get(outputAddr);
-	    		Script scriptsig = TimeLockedAddress.createScriptSig(redeemScript, false, clientSig, serverSig);
-	    		ti.setScriptSig(scriptsig);
-	    	}  
+			for (int tiIndex = 0; tiIndex < tx.getInputs().size(); ++tiIndex) {
+				TransactionInput ti = tx.getInput(tiIndex);
+				TransactionSignature clientSig = clientSigs.get(tiIndex);
+				TransactionSignature serverSig = serverSigs.get(tiIndex);
+
+				Address outputAddr = ti.getConnectedOutput().getAddressFromP2SH(params);
+				byte[] redeemScript = addressesToRedeemScripts.get(outputAddr);
+				Script scriptsig = TimeLockedAddress.createScriptSig(redeemScript, false, clientSig, serverSig);
+				ti.setScriptSig(scriptsig);
+			}
 		}
-		
+
 		public void applySignatures(Transaction tx, List<TransactionSignature> clientSigs) {
 			// apply
 			for (int tiIndex = 0; tiIndex < tx.getInputs().size(); ++tiIndex) {
@@ -569,38 +559,40 @@ public class CompleteCLTVTest extends CoinbleskTest {
 				byte[] redeemScript = addressesToRedeemScripts.get(outputAddr);
 				Script scriptsig = TimeLockedAddress.createScriptSig(redeemScript, true, clientSig);
 				ti.setScriptSig(scriptsig);
-			} 
-		}		
-		
+			}
+		}
+
 		public void verifyTx(Transaction tx) {
 			// throws if error
 			for (int tiIndex = 0; tiIndex < tx.getInputs().size(); ++tiIndex) {
 				TransactionInput ti = tx.getInput(tiIndex);
 				Script scriptsig = ti.getScriptSig();
-				scriptsig.correctlySpends(tx, tiIndex, ti.getConnectedOutput().getScriptPubKey(), Script.ALL_VERIFY_FLAGS);
+				scriptsig.correctlySpends(tx, tiIndex, ti.getConnectedOutput().getScriptPubKey(),
+						Script.ALL_VERIFY_FLAGS);
 			}
 		}
 
 		private void initWallet(File walletDir, String walletPrefix) {
-	        clientAppKit = new WalletAppKit(params, walletDir, walletPrefix);
+			clientAppKit = new WalletAppKit(params, walletDir, walletPrefix);
 			clientAppKit.setDiscovery(new PeerDiscovery() {
 				@Override
 				public void shutdown() {
 				}
 
 				@Override
-				public InetSocketAddress[] getPeers(long services, long timeoutValue, TimeUnit timeoutUnit) throws PeerDiscoveryException {
+				public InetSocketAddress[] getPeers(long services, long timeoutValue, TimeUnit timeoutUnit)
+						throws PeerDiscoveryException {
 					return new InetSocketAddress[0];
 				}
 			});
-	        clientAppKit.setBlockingStartup(false);
-	        clientAppKit.startAsync().awaitRunning();
-	        
-	        for (Address address : addressesToRedeemScripts.keySet()) {
-	        	wallet().addWatchedAddress(address);
-	        }
+			clientAppKit.setBlockingStartup(false);
+			clientAppKit.startAsync().awaitRunning();
+
+			for (Address address : addressesToRedeemScripts.keySet()) {
+				wallet().addWatchedAddress(address);
+			}
 		}
-		
+
 		public void shutdownWallet() {
 			if (clientAppKit != null) {
 				try {
@@ -610,99 +602,95 @@ public class CompleteCLTVTest extends CoinbleskTest {
 				}
 			}
 		}
-		
+
 		public Wallet wallet() {
 			return clientAppKit != null ? clientAppKit.wallet() : null;
 		}
-		
+
 		public BlockChain blockChain() {
 			return clientAppKit != null ? clientAppKit.chain() : null;
 		}
-		
+
 		public Address getChangeAddress() {
 			return mostRecentAddress;
 		}
-		
+
 		public Map<Address, byte[]> getAllAddresses() {
 			return addressesToRedeemScripts;
 		}
-		
-				
+
 		private ECKey keyExchange() throws Exception {
-			KeyTO keyTO = new KeyTO()
-					.currentDate(System.currentTimeMillis())
-					.publicKey(clientKey.getPubKey());
+			KeyTO keyTO = new KeyTO().currentDate(System.currentTimeMillis()).publicKey(clientKey.getPubKey());
 			SerializeUtils.signJSON(keyTO, clientKey);
-			
+
 			KeyTO responseTO = RESTUtils.postRequest(mockMvc, PaymentControllerTest.URL_KEY_EXCHANGE, keyTO);
 			assertTrue(responseTO.isSuccess());
 			assertNotNull(responseTO.publicKey());
-			
+
 			return ECKey.fromPublicOnly(responseTO.publicKey());
 		}
 
 		public TimeLockedAddress createTimeLockedAddress() throws Exception {
 			long locktime = (System.currentTimeMillis() + 5000L) / 1000L;
-			TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-					.currentDate(System.currentTimeMillis())
-					.lockTime(locktime)
-					.publicKey(clientKey.getPubKey());
+			TimeLockedAddressTO requestTO = new TimeLockedAddressTO()	.currentDate(System.currentTimeMillis())
+																		.lockTime(locktime)
+																		.publicKey(clientKey.getPubKey());
 			SerializeUtils.signJSON(requestTO, clientKey);
-	        MvcResult res = mockMvc
-	        		.perform(
-	        				post(PaymentControllerTest.URL_CREATE_TIME_LOCKED_ADDRESS)
-	        				.secure(true)
-	        				.contentType(MediaType.APPLICATION_JSON)
-	        				.content(SerializeUtils.GSON.toJson(requestTO)))
-	        		.andExpect(status().isOk())
-	        		.andReturn();
-	        TimeLockedAddressTO response = SerializeUtils.GSON
-	        		.fromJson(res.getResponse().getContentAsString(), TimeLockedAddressTO.class);
-	        
-	        assertTrue(response.isSuccess());
-	        TimeLockedAddress timeLockedAddress = response.timeLockedAddress();
-	        assertNotNull(timeLockedAddress);
-	        Address address = timeLockedAddress.getAddress(params);
-	        addressesToRedeemScripts.put(address, timeLockedAddress.createRedeemScript().getProgram());
-	        mostRecentAddress = address;
-	        
-	        if (wallet() != null) {
-	        	wallet().addWatchedAddress(address);
-	        }
-	        return timeLockedAddress;
+			MvcResult res = mockMvc.perform(
+					post(PaymentControllerTest.URL_CREATE_TIME_LOCKED_ADDRESS)
+					.secure(true)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(SerializeUtils.GSON.toJson(requestTO)))
+									.andExpect(status().isOk())
+									.andReturn();
+			TimeLockedAddressTO response = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
+					TimeLockedAddressTO.class);
+
+			assertTrue(response.isSuccess());
+			TimeLockedAddress timeLockedAddress = response.timeLockedAddress();
+			assertNotNull(timeLockedAddress);
+			Address address = timeLockedAddress.getAddress(params);
+			addressesToRedeemScripts.put(address, timeLockedAddress.createRedeemScript().getProgram());
+			mostRecentAddress = address;
+
+			if (wallet() != null) {
+				wallet().addWatchedAddress(address);
+			}
+			return timeLockedAddress;
 		}
-		
+
 		public SignVerifyTO signTxByServer(Transaction tx, List<TransactionSignature> clientSigs) throws Exception {
 			SignVerifyTO signTO = new SignVerifyTO()
 					.publicKey(clientKey.getPubKey())
 					.transaction(tx.unsafeBitcoinSerialize())
 					.signatures(SerializeUtils.serializeSignatures(clientSigs))
-                                        .currentDate(System.currentTimeMillis())
+					.currentDate(System.currentTimeMillis())
 					.setSuccess();
 			SerializeUtils.signJSON(signTO, clientKey);
-			
+
 			MvcResult res = mockMvc
-	        		.perform(post(PaymentControllerTest.URL_SIGN_VERIFY).secure(true)
-	        				.contentType(MediaType.APPLICATION_JSON).content(SerializeUtils.GSON.toJson(signTO)))
-	        		.andExpect(status().isOk())
-	        		.andReturn();
-			SignVerifyTO response = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), SignVerifyTO.class);
+					.perform(post(PaymentControllerTest.URL_SIGN_VERIFY).secure(true)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(SerializeUtils.GSON.toJson(signTO)))
+					.andExpect(status().isOk())
+					.andReturn();
+			SignVerifyTO response = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
+					SignVerifyTO.class);
 			return response;
 		}
-		
+
 		public List<TransactionSignature> signTxByClient(Transaction tx) throws Exception {
 			List<TransactionSignature> clientSigs = new ArrayList<>();
-	    	for (int tiIndex = 0; tiIndex < tx.getInputs().size(); ++tiIndex) {
-	    		Address outputAddr = tx.getInput(tiIndex).getConnectedOutput().getAddressFromP2SH(params);
-	    		byte[] redeemScript = addressesToRedeemScripts.get(outputAddr);
-	    		TransactionSignature sig = tx.calculateSignature(tiIndex, 
-	    				clientKey, redeemScript, 
-	    				Transaction.SigHash.ALL, false);
-	    		clientSigs.add(sig);
-	    	}
-	    	return clientSigs;
+			for (int tiIndex = 0; tiIndex < tx.getInputs().size(); ++tiIndex) {
+				Address outputAddr = tx.getInput(tiIndex).getConnectedOutput().getAddressFromP2SH(params);
+				byte[] redeemScript = addressesToRedeemScripts.get(outputAddr);
+				TransactionSignature sig = tx.calculateSignature(tiIndex, clientKey, redeemScript,
+						Transaction.SigHash.ALL, false);
+				clientSigs.add(sig);
+			}
+			return clientSigs;
 		}
-		
+
 		public ECKey getClientKey() {
 			return clientKey;
 		}
@@ -712,5 +700,5 @@ public class CompleteCLTVTest extends CoinbleskTest {
 		}
 
 	}
-	
+
 }

--- a/src/test/java/com/coinblesk/server/controller/ForexTest.java
+++ b/src/test/java/com/coinblesk/server/controller/ForexTest.java
@@ -50,9 +50,10 @@ public class ForexTest extends CoinbleskTest {
 
 	@Test
 	public void testV1() throws Exception {
-		MvcResult res = mockMvc	.perform(get("/forex/exchangeRate/CHF").secure(true))
-								.andExpect(status().isOk())
-								.andReturn();
+		MvcResult res = mockMvc
+				.perform(get("/forex/exchangeRate/CHF").secure(true))
+				.andExpect(status().isOk())
+				.andReturn();
 		ExchangeRateTO rate = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
 				ExchangeRateTO.class);
 		System.out.println("rate is: " + rate.rate() + "/" + rate.name());
@@ -61,9 +62,10 @@ public class ForexTest extends CoinbleskTest {
 
 	@Test
 	public void testV2() throws Exception {
-		MvcResult res = mockMvc	.perform(get("/v2/forex/rate/CHF-EUR").secure(true))
-								.andExpect(status().isOk())
-								.andReturn();
+		MvcResult res = mockMvc
+				.perform(get("/v2/forex/rate/CHF-EUR").secure(true))
+				.andExpect(status().isOk())
+				.andReturn();
 		ExchangeRateTO rate = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
 				ExchangeRateTO.class);
 		System.out.println("rate is: " + rate.rate() + "/" + rate.name());

--- a/src/test/java/com/coinblesk/server/controller/ForexTest.java
+++ b/src/test/java/com/coinblesk/server/controller/ForexTest.java
@@ -15,9 +15,9 @@
  */
 package com.coinblesk.server.controller;
 
-import com.coinblesk.json.v1.ExchangeRateTO;
-import com.coinblesk.server.utilTest.CoinbleskTest;
-import com.coinblesk.util.SerializeUtils;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,8 +27,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.coinblesk.json.v1.ExchangeRateTO;
+import com.coinblesk.server.utilTest.CoinbleskTest;
+import com.coinblesk.util.SerializeUtils;
 
 /**
  *
@@ -36,29 +37,36 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 
 public class ForexTest extends CoinbleskTest {
-    @Autowired
-    private WebApplicationContext webAppContext;
 
-    private static MockMvc mockMvc;
-    
-    @Before
-    public void setUp() {
-         mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
-    }
-    
-    @Test
-    public void testV1() throws Exception {
-        MvcResult res = mockMvc.perform(get("/w/x/CHF").secure(true)).andExpect(status().isOk()).andReturn();
-        ExchangeRateTO rate = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), ExchangeRateTO.class);
-        System.out.println("rate is: " + rate.rate()+"/"+rate.name());
-        Assert.assertNotNull(rate);
-    }
-    
-    @Test
-    public void testV2() throws Exception {
-        MvcResult res = mockMvc.perform(get("/v2/x/r/CHF-EUR").secure(true)).andExpect(status().isOk()).andReturn();
-        ExchangeRateTO rate = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), ExchangeRateTO.class);
-        System.out.println("rate is: " + rate.rate()+"/"+rate.name());
-        Assert.assertNotNull(rate);
-    }
+	@Autowired
+	private WebApplicationContext webAppContext;
+
+	private static MockMvc mockMvc;
+
+	@Before
+	public void setUp() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+	}
+
+	@Test
+	public void testV1() throws Exception {
+		MvcResult res = mockMvc	.perform(get("/forex/exchangeRate/CHF").secure(true))
+								.andExpect(status().isOk())
+								.andReturn();
+		ExchangeRateTO rate = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
+				ExchangeRateTO.class);
+		System.out.println("rate is: " + rate.rate() + "/" + rate.name());
+		Assert.assertNotNull(rate);
+	}
+
+	@Test
+	public void testV2() throws Exception {
+		MvcResult res = mockMvc	.perform(get("/v2/forex/rate/CHF-EUR").secure(true))
+								.andExpect(status().isOk())
+								.andReturn();
+		ExchangeRateTO rate = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(),
+				ExchangeRateTO.class);
+		System.out.println("rate is: " + rate.rate() + "/" + rate.name());
+		Assert.assertNotNull(rate);
+	}
 }

--- a/src/test/java/com/coinblesk/server/controller/GenericEndpointTest.java
+++ b/src/test/java/com/coinblesk/server/controller/GenericEndpointTest.java
@@ -43,264 +43,252 @@ import java.util.List;
  */
 public class GenericEndpointTest extends CoinbleskTest {
 
-    public final static long UNIX_TIME_MONTH = 60 * 60 * 24 * 30;
-    public final static int LOCK_TIME_MONTHS = 3;
+	public final static long UNIX_TIME_MONTH = 60 * 60 * 24 * 30;
+	public final static int LOCK_TIME_MONTHS = 3;
 
-    @Autowired
-    private WebApplicationContext webAppContext;
+	@Autowired
+	private WebApplicationContext webAppContext;
 
-    @Autowired
-    private AppConfig appConfig;
+	@Autowired
+	private AppConfig appConfig;
 
-    @Autowired
-    private WalletService walletService;
+	@Autowired
+	private WalletService walletService;
 
-    private static MockMvc mockMvc;
+	private static MockMvc mockMvc;
 
-    private NetworkParameters params;
-    
-    @Before
-    public void setUp() throws Exception {
-        walletService.shutdown();
-        mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
-        walletService.init();
-        params = appConfig.getNetworkParameters();
-    }
+	private NetworkParameters params;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testOldTime() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date(1);
-        Address merchantAddress = new ECKey().toAddress(params);
-        Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
-                merchantAddress, amountToRequest.getValue(), true);
-        // test /prepare
-        SignTO statusPrepare = ServerCalls.signServerCall(mockMvc, tx, client, now);
-        Assert.assertFalse(statusPrepare.isSuccess());
-        Assert.assertEquals(Type.TIME_MISMATCH, statusPrepare.type());
-        // test /refund-p2sh
-        RefundTO statusRefund = ServerCalls.refundServerCall(params, mockMvc, client.ecKey(), Collections
-                .emptyList(), Collections.emptyList(), now, 0);
-        Assert.assertFalse(statusRefund.isSuccess());
-        Assert.assertEquals(Type.TIME_MISMATCH, statusRefund.type());
-        // test /complete-sign
-        VerifyTO statusSign = ServerCalls.verifyServerCall(mockMvc, client.ecKey(), client.p2shAddress(),
-                new Transaction(params), now);
-        Assert.assertFalse(statusSign.isSuccess());
-        Assert.assertEquals(Type.TIME_MISMATCH, statusSign.type());
+	@Before
+	public void setUp() throws Exception {
+		walletService.shutdown();
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+		walletService.init();
+		params = appConfig.getNetworkParameters();
+	}
 
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testOldTime() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date(1);
+		Address merchantAddress = new ECKey().toAddress(params);
+		Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
+				merchantAddress, amountToRequest.getValue(), true);
+		// test /prepare
+		SignTO statusPrepare = ServerCalls.signServerCall(mockMvc, tx, client, now);
+		Assert.assertFalse(statusPrepare.isSuccess());
+		Assert.assertEquals(Type.TIME_MISMATCH, statusPrepare.type());
+		// test /refund-p2sh
+		RefundTO statusRefund = ServerCalls.refundServerCall(params, mockMvc, client.ecKey(), Collections.emptyList(),
+				Collections.emptyList(), now, 0);
+		Assert.assertFalse(statusRefund.isSuccess());
+		Assert.assertEquals(Type.TIME_MISMATCH, statusRefund.type());
+		// test /complete-sign
+		VerifyTO statusSign = ServerCalls.verifyServerCall(mockMvc, client.ecKey(), client.p2shAddress(),
+				new Transaction(params), now);
+		Assert.assertFalse(statusSign.isSuccess());
+		Assert.assertEquals(Type.TIME_MISMATCH, statusSign.type());
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testNewTime() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date(Long.MAX_VALUE / 2);
-        Address merchantAddress = new ECKey().toAddress(params);
-        Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
-                merchantAddress, amountToRequest.getValue(), true);
-        // test /prepare
-        SignTO status = ServerCalls.signServerCall(mockMvc, tx, client, now);
-        Assert.assertFalse(status.isSuccess());
-        Assert.assertEquals(Type.TIME_MISMATCH, status.type());
-        // test /refund-p2sh
-        RefundTO statusRefund = ServerCalls.refundServerCall(params, mockMvc, client.ecKey(), Collections
-                .emptyList(), Collections.emptyList(), now, 0);
-        Assert.assertFalse(statusRefund.isSuccess());
-        Assert.assertEquals(Type.TIME_MISMATCH, statusRefund.type());
-        // test /complete-sign
-        VerifyTO statusSign = ServerCalls.verifyServerCall(mockMvc, client.ecKey(), client.p2shAddress(),
-                new Transaction(params), now);
-        Assert.assertFalse(statusSign.isSuccess());
-        Assert.assertEquals(Type.TIME_MISMATCH, statusSign.type());
-    }
+	}
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testWrongSignature() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date();
-        Address merchantAddress = new ECKey().toAddress(params);
-        Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
-                merchantAddress, amountToRequest.getValue(), true);
-        // test /prepare
-        SignTO prepareHalfSignTO = ServerCalls.signServerCallInput(tx, client.ecKey(), now);
-        SerializeUtils.signJSON(prepareHalfSignTO, new ECKey());
-        SignTO statusPrepare = ServerCalls.signServerCallOutput(mockMvc, prepareHalfSignTO);
-        Assert.assertFalse(statusPrepare.isSuccess());
-        Assert.assertEquals(Type.JSON_SIGNATURE_ERROR, statusPrepare.type());
-        // test /refund-p2sh
-        RefundTO refundP2shTO = ServerCalls.refundServerCallInput(params, client.ecKey(), Collections
-                .emptyList(), Collections.emptyList(), now, 0);
-        SerializeUtils.signJSON(refundP2shTO, new ECKey());
-        RefundTO statusRefund = ServerCalls.refundServerCallOutput(mockMvc, refundP2shTO);
-        Assert.assertFalse(statusRefund.isSuccess());
-        Assert.assertEquals(Type.JSON_SIGNATURE_ERROR, statusRefund.type());
-        // test /complete-sign
-        VerifyTO completeSignTO = ServerCalls.verifyServerCallInput(client.ecKey(), client.p2shAddress(),
-                new Transaction(params), now);
-        SerializeUtils.signJSON(completeSignTO, new ECKey());
-        VerifyTO statusSign = ServerCalls.verifyServerCallOutput(mockMvc, completeSignTO);
-        Assert.assertFalse(statusSign.isSuccess());
-        Assert.assertEquals(Type.JSON_SIGNATURE_ERROR, statusSign.type());
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testNewTime() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date(Long.MAX_VALUE / 2);
+		Address merchantAddress = new ECKey().toAddress(params);
+		Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
+				merchantAddress, amountToRequest.getValue(), true);
+		// test /prepare
+		SignTO status = ServerCalls.signServerCall(mockMvc, tx, client, now);
+		Assert.assertFalse(status.isSuccess());
+		Assert.assertEquals(Type.TIME_MISMATCH, status.type());
+		// test /refund-p2sh
+		RefundTO statusRefund = ServerCalls.refundServerCall(params, mockMvc, client.ecKey(), Collections.emptyList(),
+				Collections.emptyList(), now, 0);
+		Assert.assertFalse(statusRefund.isSuccess());
+		Assert.assertEquals(Type.TIME_MISMATCH, statusRefund.type());
+		// test /complete-sign
+		VerifyTO statusSign = ServerCalls.verifyServerCall(mockMvc, client.ecKey(), client.p2shAddress(),
+				new Transaction(params), now);
+		Assert.assertFalse(statusSign.isSuccess());
+		Assert.assertEquals(Type.TIME_MISMATCH, statusSign.type());
+	}
 
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testWrongSignature() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date();
+		Address merchantAddress = new ECKey().toAddress(params);
+		Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
+				merchantAddress, amountToRequest.getValue(), true);
+		// test /prepare
+		SignTO prepareHalfSignTO = ServerCalls.signServerCallInput(tx, client.ecKey(), now);
+		SerializeUtils.signJSON(prepareHalfSignTO, new ECKey());
+		SignTO statusPrepare = ServerCalls.signServerCallOutput(mockMvc, prepareHalfSignTO);
+		Assert.assertFalse(statusPrepare.isSuccess());
+		Assert.assertEquals(Type.JSON_SIGNATURE_ERROR, statusPrepare.type());
+		// test /refund-p2sh
+		RefundTO refundP2shTO = ServerCalls.refundServerCallInput(params, client.ecKey(), Collections.emptyList(),
+				Collections.emptyList(), now, 0);
+		SerializeUtils.signJSON(refundP2shTO, new ECKey());
+		RefundTO statusRefund = ServerCalls.refundServerCallOutput(mockMvc, refundP2shTO);
+		Assert.assertFalse(statusRefund.isSuccess());
+		Assert.assertEquals(Type.JSON_SIGNATURE_ERROR, statusRefund.type());
+		// test /complete-sign
+		VerifyTO completeSignTO = ServerCalls.verifyServerCallInput(client.ecKey(), client.p2shAddress(),
+				new Transaction(params), now);
+		SerializeUtils.signJSON(completeSignTO, new ECKey());
+		VerifyTO statusSign = ServerCalls.verifyServerCallOutput(mockMvc, completeSignTO);
+		Assert.assertFalse(statusSign.isSuccess());
+		Assert.assertEquals(Type.JSON_SIGNATURE_ERROR, statusSign.type());
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testNotRegistered() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date();
-        Address merchantAddress = new ECKey().toAddress(params);
-        Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
-                merchantAddress, amountToRequest.getValue(), true);
-        // test /prepare
-        ECKey key = new ECKey();
-        SignTO prepareHalfSignTO = ServerCalls.signServerCallInput(tx, key, now);
-        SerializeUtils.signJSON(prepareHalfSignTO, key);
-        SignTO status = ServerCalls.signServerCallOutput(mockMvc, prepareHalfSignTO);
-        Assert.assertFalse(status.isSuccess());
-        Assert.assertEquals(Type.KEYS_NOT_FOUND, status.type());
-        // test /refund-p2sh
-        RefundTO refundP2shTO = ServerCalls.refundServerCallInput(params, key, Collections.emptyList(),
-                Collections.emptyList(), now, 0);
-        SerializeUtils.signJSON(refundP2shTO, key);
-        RefundTO statusRefund = ServerCalls.refundServerCallOutput(mockMvc, refundP2shTO);
-        Assert.assertFalse(statusRefund.isSuccess());
-        Assert.assertEquals(Type.KEYS_NOT_FOUND, statusRefund.type());
-        // test /complete-sign
-        VerifyTO completeSignTO = ServerCalls.verifyServerCallInput(key, client.p2shAddress(),
-                new Transaction(params), now);
-        SerializeUtils.signJSON(completeSignTO, key);
-        VerifyTO statusSign = ServerCalls.verifyServerCallOutput(mockMvc, completeSignTO);
-        Assert.assertFalse(statusSign.isSuccess());
-        Assert.assertEquals(Type.KEYS_NOT_FOUND, statusSign.type());
-    }
+	}
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testIdempotent() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date();
-        Address merchantAddress = new ECKey().toAddress(params);
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testNotRegistered() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date();
+		Address merchantAddress = new ECKey().toAddress(params);
+		Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
+				merchantAddress, amountToRequest.getValue(), true);
+		// test /prepare
+		ECKey key = new ECKey();
+		SignTO prepareHalfSignTO = ServerCalls.signServerCallInput(tx, key, now);
+		SerializeUtils.signJSON(prepareHalfSignTO, key);
+		SignTO status = ServerCalls.signServerCallOutput(mockMvc, prepareHalfSignTO);
+		Assert.assertFalse(status.isSuccess());
+		Assert.assertEquals(Type.KEYS_NOT_FOUND, status.type());
+		// test /refund-p2sh
+		RefundTO refundP2shTO = ServerCalls.refundServerCallInput(params, key, Collections.emptyList(),
+				Collections.emptyList(), now, 0);
+		SerializeUtils.signJSON(refundP2shTO, key);
+		RefundTO statusRefund = ServerCalls.refundServerCallOutput(mockMvc, refundP2shTO);
+		Assert.assertFalse(statusRefund.isSuccess());
+		Assert.assertEquals(Type.KEYS_NOT_FOUND, statusRefund.type());
+		// test /complete-sign
+		VerifyTO completeSignTO = ServerCalls.verifyServerCallInput(key, client.p2shAddress(), new Transaction(params),
+				now);
+		SerializeUtils.signJSON(completeSignTO, key);
+		VerifyTO statusSign = ServerCalls.verifyServerCallOutput(mockMvc, completeSignTO);
+		Assert.assertFalse(statusSign.isSuccess());
+		Assert.assertEquals(Type.KEYS_NOT_FOUND, statusSign.type());
+	}
 
-        Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
-                merchantAddress, amountToRequest.getValue(), true);
-        // test /sign
-        SignTO statusPrepare1 = ServerCalls.signServerCall(mockMvc, tx, client, now);
-        Assert.assertTrue(statusPrepare1.isSuccess());
-        // again -> results in same output        
-        SignTO statusPrepare2 = ServerCalls.signServerCall(mockMvc, tx, client, now);
-        Assert.assertTrue(statusPrepare2.isSuccess());
-        Assert.assertEquals(SerializeUtils.GSON.toJson(statusPrepare1), SerializeUtils.GSON.toJson(
-                statusPrepare2));
-        // option 2
-        List<Pair<byte[], Long>> outpointCoinPair1 = convert(t.getOutputs());
-        SignTO statusPrepare3 = ServerCalls.signServerCall(mockMvc, outpointCoinPair1, merchantAddress,
-                amountToRequest.getValue(), client, now);
-        Assert.assertTrue(statusPrepare3.isSuccess());
-        // again -> results in same output
-        List<Pair<byte[], Long>> outpointCoinPair2 = convert(t.getOutputs());
-        SignTO statusPrepare4 = ServerCalls.signServerCall(mockMvc, outpointCoinPair2, merchantAddress,
-                amountToRequest.getValue(), client, now);
-        Assert.assertTrue(statusPrepare4.isSuccess());
-        Assert.assertEquals(SerializeUtils.GSON.toJson(statusPrepare3), SerializeUtils.GSON.toJson(
-                statusPrepare4));
-        //now we have the sigs and we can fully sign the tx
-        Transaction transaction = BitcoinUtils.createTx(params, convert2(t.getOutputs()), client
-                .redeemScript(),
-                client.p2shAddress(),
-                merchantAddress, amountToRequest.getValue(), true);
-        List<TransactionSignature> clientSigs = BitcoinUtils.partiallySign(transaction, client.redeemScript(),
-                client.ecKey());
-        List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(statusPrepare4
-                .signatures());
-        
-        BitcoinUtils.applySignatures(transaction, client.redeemScript(),
-                clientSigs, serverSigs, client.clientFirst());
-        Coin fee = transaction.getFee();
-        int len = transaction.unsafeBitcoinSerialize().length;
-        System.out.println("tx len: " + len);
-        Assert.assertEquals(30, Math.round(fee.getValue() / (double) len));
-        // test /refund
-        //create a refund with outpoint.
-        TransactionOutput output = transaction.getOutput(1);
-        List<Pair<TransactionOutPoint, Coin>> refundOutpoints = new ArrayList<>(1);
-        refundOutpoints.add(new Pair<>(output.getOutPointFor(), output.getValue()));
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testIdempotent() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction t = sendFakeCoins(Coin.valueOf(123450), client.p2shAddress());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date();
+		Address merchantAddress = new ECKey().toAddress(params);
 
-        //now + 1min
-        long lockTimeSeconds = (System.currentTimeMillis() / 1000) + 60;
-        Transaction refundTx = BitcoinUtils.createRefundTx(params, refundOutpoints, client.redeemScript(),
-                client.ecKey().toAddress(params), lockTimeSeconds);
+		Transaction tx = BitcoinUtils.createTx(params, client.outpoints(t), client.redeemScript(), client.p2shAddress(),
+				merchantAddress, amountToRequest.getValue(), true);
+		// test /sign
+		SignTO statusPrepare1 = ServerCalls.signServerCall(mockMvc, tx, client, now);
+		Assert.assertTrue(statusPrepare1.isSuccess());
+		// again -> results in same output
+		SignTO statusPrepare2 = ServerCalls.signServerCall(mockMvc, tx, client, now);
+		Assert.assertTrue(statusPrepare2.isSuccess());
+		Assert.assertEquals(SerializeUtils.GSON.toJson(statusPrepare1), SerializeUtils.GSON.toJson(statusPrepare2));
+		// option 2
+		List<Pair<byte[], Long>> outpointCoinPair1 = convert(t.getOutputs());
+		SignTO statusPrepare3 = ServerCalls.signServerCall(mockMvc, outpointCoinPair1, merchantAddress,
+				amountToRequest.getValue(), client, now);
+		Assert.assertTrue(statusPrepare3.isSuccess());
+		// again -> results in same output
+		List<Pair<byte[], Long>> outpointCoinPair2 = convert(t.getOutputs());
+		SignTO statusPrepare4 = ServerCalls.signServerCall(mockMvc, outpointCoinPair2, merchantAddress,
+				amountToRequest.getValue(), client, now);
+		Assert.assertTrue(statusPrepare4.isSuccess());
+		Assert.assertEquals(SerializeUtils.GSON.toJson(statusPrepare3), SerializeUtils.GSON.toJson(statusPrepare4));
+		// now we have the sigs and we can fully sign the tx
+		Transaction transaction = BitcoinUtils.createTx(params, convert2(t.getOutputs()), client.redeemScript(),
+				client.p2shAddress(), merchantAddress, amountToRequest.getValue(), true);
+		List<TransactionSignature> clientSigs = BitcoinUtils.partiallySign(transaction, client.redeemScript(),
+				client.ecKey());
+		List<TransactionSignature> serverSigs = SerializeUtils.deserializeSignatures(statusPrepare4.signatures());
 
-        List<TransactionSignature> clientSigsRefund = BitcoinUtils.partiallySign(refundTx, client
-                .redeemScript(), client.ecKey());
+		BitcoinUtils.applySignatures(transaction, client.redeemScript(), clientSigs, serverSigs, client.clientFirst());
+		Coin fee = transaction.getFee();
+		int len = transaction.unsafeBitcoinSerialize().length;
+		System.out.println("tx len: " + len);
+		Assert.assertEquals(30, Math.round(fee.getValue() / (double) len));
+		// test /refund
+		// create a refund with outpoint.
+		TransactionOutput output = transaction.getOutput(1);
+		List<Pair<TransactionOutPoint, Coin>> refundOutpoints = new ArrayList<>(1);
+		refundOutpoints.add(new Pair<>(output.getOutPointFor(), output.getValue()));
 
-        RefundTO statusRefund1 = ServerCalls
-                .refundServerCall(params, mockMvc, client.ecKey(), refundOutpoints, clientSigsRefund, now,
-                        lockTimeSeconds);
-        Assert.assertTrue(statusRefund1.isSuccess());
+		// now + 1min
+		long lockTimeSeconds = (System.currentTimeMillis() / 1000) + 60;
+		Transaction refundTx = BitcoinUtils.createRefundTx(params, refundOutpoints, client.redeemScript(),
+				client.ecKey().toAddress(params), lockTimeSeconds);
 
-        RefundTO statusRefund2 = ServerCalls
-                .refundServerCall(params, mockMvc, client.ecKey(), refundOutpoints, clientSigsRefund, now,
-                        lockTimeSeconds);
-        Assert.assertTrue(statusRefund1.isSuccess());
-        Assert.assertEquals(SerializeUtils.GSON.toJson(statusRefund1), SerializeUtils.GSON.toJson(
-                statusRefund2));
+		List<TransactionSignature> clientSigsRefund = BitcoinUtils.partiallySign(refundTx, client.redeemScript(),
+				client.ecKey());
 
-        // test /complete-sign
-        VerifyTO statusVerify1 = ServerCalls.verifyServerCall(mockMvc, outpointCoinPair2, merchantAddress,
-                amountToRequest.getValue(), client,
-                SerializeUtils.serializeSignatures(clientSigs), SerializeUtils.serializeSignatures(serverSigs),
-                now);
-        Assert.assertTrue(statusVerify1.isSuccess());
-        VerifyTO statusVerify2 = ServerCalls.verifyServerCall(mockMvc, outpointCoinPair2, merchantAddress,
-                amountToRequest.getValue(), client,
-                SerializeUtils.serializeSignatures(clientSigs), SerializeUtils.serializeSignatures(serverSigs),
-                now);
-        Assert.assertTrue(statusVerify2.isSuccess());
-        Assert.assertEquals(SerializeUtils.GSON.toJson(statusVerify1), SerializeUtils.GSON.toJson(
-                statusVerify2));
-    }
+		RefundTO statusRefund1 = ServerCalls.refundServerCall(params, mockMvc, client.ecKey(), refundOutpoints,
+				clientSigsRefund, now, lockTimeSeconds);
+		Assert.assertTrue(statusRefund1.isSuccess());
 
-    private Transaction sendFakeCoins(Coin amount, Address to) throws VerificationException, PrunedException, BlockStoreException, InterruptedException {
-        Transaction tx = FakeTxBuilder.createFakeTx(params, amount, to);
-        BlockChain chain = walletService.blockChain();
-        Block block = FakeTxBuilder.makeSolvedTestBlock(chain.getBlockStore().getChainHead().getHeader(), tx);
-        chain.add(block);
-        return tx;
-    }
+		RefundTO statusRefund2 = ServerCalls.refundServerCall(params, mockMvc, client.ecKey(), refundOutpoints,
+				clientSigsRefund, now, lockTimeSeconds);
+		Assert.assertTrue(statusRefund1.isSuccess());
+		Assert.assertEquals(SerializeUtils.GSON.toJson(statusRefund1), SerializeUtils.GSON.toJson(statusRefund2));
 
-    private static List<Pair<byte[], Long>> convert(List<TransactionOutput> outputs) {
-        List<Pair<byte[], Long>> retVal = new ArrayList<>(outputs.size());
-        for (TransactionOutput output : outputs) {
-            retVal.add(new Pair<>(output.getOutPointFor().unsafeBitcoinSerialize(), output.getValue()
-                    .getValue()));
-        }
-        return retVal;
-    }
+		// test /complete-sign
+		VerifyTO statusVerify1 = ServerCalls.verifyServerCall(mockMvc, outpointCoinPair2, merchantAddress,
+				amountToRequest.getValue(), client, SerializeUtils.serializeSignatures(clientSigs),
+				SerializeUtils.serializeSignatures(serverSigs), now);
+		Assert.assertTrue(statusVerify1.isSuccess());
+		VerifyTO statusVerify2 = ServerCalls.verifyServerCall(mockMvc, outpointCoinPair2, merchantAddress,
+				amountToRequest.getValue(), client, SerializeUtils.serializeSignatures(clientSigs),
+				SerializeUtils.serializeSignatures(serverSigs), now);
+		Assert.assertTrue(statusVerify2.isSuccess());
+		Assert.assertEquals(SerializeUtils.GSON.toJson(statusVerify1), SerializeUtils.GSON.toJson(statusVerify2));
+	}
 
-    private static List<Pair<TransactionOutPoint, Coin>> convert2(List<TransactionOutput> outputs) {
-        List<Pair<TransactionOutPoint, Coin>> retVal = new ArrayList<>(outputs.size());
-        for (TransactionOutput output : outputs) {
-            retVal.add(new Pair<>(output.getOutPointFor(), output.getValue()));
-        }
-        return retVal;
-    }
+	private Transaction sendFakeCoins(Coin amount, Address to)
+			throws VerificationException, PrunedException, BlockStoreException, InterruptedException {
+		Transaction tx = FakeTxBuilder.createFakeTx(params, amount, to);
+		BlockChain chain = walletService.blockChain();
+		Block block = FakeTxBuilder.makeSolvedTestBlock(chain.getBlockStore().getChainHead().getHeader(), tx);
+		chain.add(block);
+		return tx;
+	}
+
+	private static List<Pair<byte[], Long>> convert(List<TransactionOutput> outputs) {
+		List<Pair<byte[], Long>> retVal = new ArrayList<>(outputs.size());
+		for (TransactionOutput output : outputs) {
+			retVal.add(new Pair<>(output.getOutPointFor().unsafeBitcoinSerialize(), output.getValue().getValue()));
+		}
+		return retVal;
+	}
+
+	private static List<Pair<TransactionOutPoint, Coin>> convert2(List<TransactionOutput> outputs) {
+		List<Pair<TransactionOutPoint, Coin>> retVal = new ArrayList<>(outputs.size());
+		for (TransactionOutput output : outputs) {
+			retVal.add(new Pair<>(output.getOutPointFor(), output.getValue()));
+		}
+		return retVal;
+	}
 }

--- a/src/test/java/com/coinblesk/server/controller/PaymentControllerTest.java
+++ b/src/test/java/com/coinblesk/server/controller/PaymentControllerTest.java
@@ -15,6 +15,27 @@
  */
 package com.coinblesk.server.controller;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Random;
+
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
 import com.coinblesk.bitcoin.TimeLockedAddress;
 import com.coinblesk.json.v1.BaseTO;
 import com.coinblesk.json.v1.KeyTO;
@@ -28,45 +49,29 @@ import com.coinblesk.util.BitcoinUtils;
 import com.coinblesk.util.SerializeUtils;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
-import org.bitcoinj.core.ECKey;
-import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Utils;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-
-import java.util.Random;
-
-import static org.junit.Assert.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 /**
- * 
+ *
  * @author Andreas Albrecht
  */
 public class PaymentControllerTest extends CoinbleskTest {
-	
+
 	public static final String URL_KEY_EXCHANGE = "/v1/payment/key-exchange";
 	public static final String URL_CREATE_TIME_LOCKED_ADDRESS = "/v1/payment/createTimeLockedAddress";
 	public static final String URL_SIGN_VERIFY = "/v1/payment/signverify";
-	
-	@Autowired
-    private WebApplicationContext webAppContext;
 
-    @Autowired
-    private KeyService keyService;
-    
-    private static MockMvc mockMvc;
-    
-    @Before
-    public void setUp() {
-         mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
-    }
+	@Autowired
+	private WebApplicationContext webAppContext;
+
+	@Autowired
+	private KeyService keyService;
+
+	private static MockMvc mockMvc;
+
+	@Before
+	public void setUp() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+	}
 
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
@@ -76,100 +81,100 @@ public class PaymentControllerTest extends CoinbleskTest {
 			.perform(post(URL_KEY_EXCHANGE).secure(true))
 			.andExpect(status().is4xxClientError());
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testKeyExchange_EmptyRequest() throws Exception {
-	    KeyTO requestTO = new KeyTO();
-	    KeyTO response = requestKeyExchange(requestTO);
-	    assertFalse(response.isSuccess());
-	    assertEquals(response.type(), Type.INPUT_MISMATCH);
+		KeyTO requestTO = new KeyTO();
+		KeyTO response = requestKeyExchange(requestTO);
+		assertFalse(response.isSuccess());
+		assertEquals(response.type(), Type.INPUT_MISMATCH);
 		assertNull(response.publicKey());
 	}
-    
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testKeyExchange_NoPubKey() throws Exception {
-    	KeyTO requestTO = new KeyTO();
-    	requestTO.currentDate(System.currentTimeMillis());
-    	
-	    KeyTO response = requestKeyExchange(requestTO);
-	    assertFalse(response.isSuccess());
-	    assertEquals(response.type(), Type.INPUT_MISMATCH);
+	public void testKeyExchange_NoPubKey() throws Exception {
+		KeyTO requestTO = new KeyTO();
+		requestTO.currentDate(System.currentTimeMillis());
+
+		KeyTO response = requestKeyExchange(requestTO);
+		assertFalse(response.isSuccess());
+		assertEquals(response.type(), Type.INPUT_MISMATCH);
 		assertNull(response.publicKey());
-    }
-    
-    @Test
+	}
+
+	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testKeyExchange_InvalidPubKey() throws Exception {
-    	KeyTO requestTO = new KeyTO()
-    		.currentDate(System.currentTimeMillis())
-    		.publicKey("invalid key".getBytes());
-    	
-	    KeyTO response = requestKeyExchange(requestTO);
-	    assertFalse(response.isSuccess());
-	    assertEquals(response.type(), Type.INPUT_MISMATCH);
+	public void testKeyExchange_InvalidPubKey() throws Exception {
+		KeyTO requestTO = new KeyTO()
+			.currentDate(System.currentTimeMillis())
+			.publicKey("invalid key".getBytes());
+
+		KeyTO response = requestKeyExchange(requestTO);
+		assertFalse(response.isSuccess());
+		assertEquals(response.type(), Type.INPUT_MISMATCH);
 		assertNull(response.publicKey());
-    }
-    
-    @Test
+	}
+
+	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testKeyExchange() throws Exception {
-    	ECKey key = new ECKey();
-    	KeyTO requestTO = new KeyTO()
-    		.currentDate(System.currentTimeMillis())
-    		.publicKey(key.getPubKey());
-    	
-	    KeyTO response = requestKeyExchange(requestTO);
-	    assertTrue(response.isSuccess());
-	    assertEquals(response.type(), Type.SUCCESS);
+	public void testKeyExchange() throws Exception {
+		ECKey key = new ECKey();
+		KeyTO requestTO = new KeyTO()
+			.currentDate(System.currentTimeMillis())
+			.publicKey(key.getPubKey());
+
+		KeyTO response = requestKeyExchange(requestTO);
+		assertTrue(response.isSuccess());
+		assertEquals(response.type(), Type.SUCCESS);
 		assertNotNull(response.publicKey());
 		assertTrue(ECKey.isPubKeyCanonical(response.publicKey()));
-		
+
 		// throws if invalid
-		ECKey serverPubKey = ECKey.fromPublicOnly(response.publicKey()); 
+		ECKey serverPubKey = ECKey.fromPublicOnly(response.publicKey());
 		assertTrue(SerializeUtils.verifyJSONSignature(response, serverPubKey));
-    }
-    
-    @Test
+	}
+
+	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testKeyExchange_ExistingPubKey() throws Exception {
-    	ECKey key = new ECKey();
-    	KeyTO requestTO = new KeyTO()
-    		.currentDate(System.currentTimeMillis())
-    		.publicKey(key.getPubKey());
-    	
-	    KeyTO response = requestKeyExchange(requestTO);
-	    assertTrue(response.isSuccess());
-	    assertEquals(response.type(), Type.SUCCESS);
+	public void testKeyExchange_ExistingPubKey() throws Exception {
+		ECKey key = new ECKey();
+		KeyTO requestTO = new KeyTO()
+			.currentDate(System.currentTimeMillis())
+			.publicKey(key.getPubKey());
+
+		KeyTO response = requestKeyExchange(requestTO);
+		assertTrue(response.isSuccess());
+		assertEquals(response.type(), Type.SUCCESS);
 		assertNotNull(response.publicKey());
-		
+
 		// throws if invalid
-		ECKey serverPubKey = ECKey.fromPublicOnly(response.publicKey()); 
+		ECKey serverPubKey = ECKey.fromPublicOnly(response.publicKey());
 		assertTrue(SerializeUtils.verifyJSONSignature(response, serverPubKey));
-		
+
 		// execute 2nd request - server should respond with same key.
-    	KeyTO request2TO = new KeyTO()
-    		.currentDate(System.currentTimeMillis())
-    		.publicKey(key.getPubKey());
+		KeyTO request2TO = new KeyTO()
+			.currentDate(System.currentTimeMillis())
+			.publicKey(key.getPubKey());
 		KeyTO response_2 = requestKeyExchange(request2TO);
 		assertTrue(response_2.isSuccess());
 		assertEquals(response_2.type(), Type.SUCCESS_BUT_KEY_ALREADY_EXISTS);
 		assertNotNull(response_2.publicKey());
 		assertArrayEquals(response_2.publicKey(), response.publicKey());
 		assertTrue(SerializeUtils.verifyJSONSignature(response_2, serverPubKey));
-    }
-    
-    private KeyTO requestKeyExchange(KeyTO requestTO) throws Exception {
-		String jsonTO = SerializeUtils.GSON.toJson(requestTO);
-        return RESTUtils.postRequest(mockMvc, URL_KEY_EXCHANGE, jsonTO, KeyTO.class);
 	}
-    
+
+	private KeyTO requestKeyExchange(KeyTO requestTO) throws Exception {
+		String jsonTO = SerializeUtils.GSON.toJson(requestTO);
+		return RESTUtils.postRequest(mockMvc, URL_KEY_EXCHANGE, jsonTO, KeyTO.class);
+	}
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
@@ -178,30 +183,30 @@ public class PaymentControllerTest extends CoinbleskTest {
 			.perform(post(URL_CREATE_TIME_LOCKED_ADDRESS).secure(true))
 			.andExpect(status().is4xxClientError());
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_EmptyRequest() throws Exception {
-	    TimeLockedAddressTO requestTO = new TimeLockedAddressTO();
-	    TimeLockedAddressTO response = requestCreateTimeLockedAddress(requestTO);
-	    assertFalse(response.isSuccess());
-	    assertEquals(response.type(), Type.INPUT_MISMATCH);
+		TimeLockedAddressTO requestTO = new TimeLockedAddressTO();
+		TimeLockedAddressTO response = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(response.isSuccess());
+		assertEquals(response.type(), Type.INPUT_MISMATCH);
 		assertNull(response.timeLockedAddress());
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_NoPublicKey() throws Exception {
 		ECKey clientKey = new ECKey();
-	    TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-	    		.currentDate(System.currentTimeMillis());
-	    SerializeUtils.signJSON(requestTO, clientKey);
-	    
-	    TimeLockedAddressTO response = requestCreateTimeLockedAddress(requestTO);
-	    assertFalse(response.isSuccess());
-	    assertEquals(response.type(), Type.SERVER_ERROR);
+		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
+				.currentDate(System.currentTimeMillis());
+		SerializeUtils.signJSON(requestTO, clientKey);
+
+		TimeLockedAddressTO response = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(response.isSuccess());
+		assertEquals(response.type(), Type.SERVER_ERROR);
 		assertNull(response.timeLockedAddress());
 	}
 
@@ -209,31 +214,31 @@ public class PaymentControllerTest extends CoinbleskTest {
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_NoSignature() throws Exception {
-        ECKey clientKey = new ECKey();
-        TimeLockedAddressTO requestTO = createSignedTimeLockedAddressTO(clientKey);
-        requestTO.messageSig(null); // Do not sign
-        
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertFalse(responseTO.isSuccess());
-        assertEquals(responseTO.type(), Type.INPUT_MISMATCH);
+		ECKey clientKey = new ECKey();
+		TimeLockedAddressTO requestTO = createSignedTimeLockedAddressTO(clientKey);
+		requestTO.messageSig(null); // Do not sign
+
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(responseTO.isSuccess());
+		assertEquals(responseTO.type(), Type.INPUT_MISMATCH);
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_WrongSignature() throws Exception {
-        ECKey clientKey = new ECKey();
-        ECKey wrongKey = new ECKey();
-        TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-        		.currentDate(Utils.currentTimeMillis())
-        		.publicKey(clientKey.getPubKey());
-        SerializeUtils.signJSON(requestTO, wrongKey);
-        
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertFalse(responseTO.isSuccess());
-        assertEquals(responseTO.type(), Type.JSON_SIGNATURE_ERROR);
+		ECKey clientKey = new ECKey();
+		ECKey wrongKey = new ECKey();
+		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
+				.currentDate(Utils.currentTimeMillis())
+				.publicKey(clientKey.getPubKey());
+		SerializeUtils.signJSON(requestTO, wrongKey);
+
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(responseTO.isSuccess());
+		assertEquals(responseTO.type(), Type.JSON_SIGNATURE_ERROR);
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
@@ -242,26 +247,26 @@ public class PaymentControllerTest extends CoinbleskTest {
 				.publicKey("helloworld".getBytes())
 				.currentDate(System.currentTimeMillis());
 		SerializeUtils.signJSON(requestTO, new ECKey());
-	    
-	    TimeLockedAddressTO response = requestCreateTimeLockedAddress(requestTO);
-	    assertFalse(response.isSuccess());
-	    assertEquals(response.type(), Type.SERVER_ERROR);
+
+		TimeLockedAddressTO response = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(response.isSuccess());
+		assertEquals(response.type(), Type.SERVER_ERROR);
 		assertNull(response.timeLockedAddress());
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testCreateTimeLockedAddress_NewAddress_ClientUnknown() throws Exception {
-        ECKey clientKey = new ECKey();
-        assertNull( keyService.getByClientPublicKey(clientKey.getPubKey()) ); // not known yet
-        TimeLockedAddressTO requestTO = createSignedTimeLockedAddressTO(clientKey);
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertFalse(responseTO.isSuccess());
-        assertNull(responseTO.timeLockedAddress());
-        assertEquals(responseTO.type(), Type.KEYS_NOT_FOUND);
-    }
-	
+	public void testCreateTimeLockedAddress_NewAddress_ClientUnknown() throws Exception {
+		ECKey clientKey = new ECKey();
+		assertNull(keyService.getByClientPublicKey(clientKey.getPubKey()) ); // not known yet
+		TimeLockedAddressTO requestTO = createSignedTimeLockedAddressTO(clientKey);
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(responseTO.isSuccess());
+		assertNull(responseTO.timeLockedAddress());
+		assertEquals(responseTO.type(), Type.KEYS_NOT_FOUND);
+	}
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseSetup("/keys.xml")
@@ -269,52 +274,52 @@ public class PaymentControllerTest extends CoinbleskTest {
 	public void testCreateTimeLockedAddress_NoLockTime() throws Exception {
 		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
 		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-		    		.currentDate(Utils.currentTimeMillis())
-		    		.publicKey(clientKey.getPubKey());
-	    SerializeUtils.signJSON(requestTO, clientKey);
-	    
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertFalse(responseTO.isSuccess());
-        assertNull(responseTO.timeLockedAddress());
-        assertEquals(responseTO.type(), Type.LOCKTIME_ERROR);
+					.currentDate(Utils.currentTimeMillis())
+					.publicKey(clientKey.getPubKey());
+		SerializeUtils.signJSON(requestTO, clientKey);
+
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(responseTO.isSuccess());
+		assertNull(responseTO.timeLockedAddress());
+		assertEquals(responseTO.type(), Type.LOCKTIME_ERROR);
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseSetup("/keys.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_LockTimeByBlock() throws Exception {
 		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-		long lockTime = Transaction.LOCKTIME_THRESHOLD-1000;
+		long lockTime = Transaction.LOCKTIME_THRESHOLD - 1000;
 		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-		    		.currentDate(Utils.currentTimeMillis())
-		    		.publicKey(clientKey.getPubKey())
-		    		.lockTime(lockTime);
-	    SerializeUtils.signJSON(requestTO, clientKey);
-	    
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertFalse(responseTO.isSuccess());
-        assertNull(responseTO.timeLockedAddress());
-        assertEquals(responseTO.type(), Type.LOCKTIME_ERROR);
+					.currentDate(Utils.currentTimeMillis())
+					.publicKey(clientKey.getPubKey())
+					.lockTime(lockTime);
+		SerializeUtils.signJSON(requestTO, clientKey);
+
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(responseTO.isSuccess());
+		assertNull(responseTO.timeLockedAddress());
+		assertEquals(responseTO.type(), Type.LOCKTIME_ERROR);
 	}
-	
+
 	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseSetup("/keys.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_LockTimeInPast() throws Exception {
 		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-		long lockTime = Utils.currentTimeSeconds()-1;
+		long lockTime = Utils.currentTimeSeconds() - 1;
 		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-		    		.currentDate(Utils.currentTimeMillis())
-		    		.publicKey(clientKey.getPubKey())
-		    		.lockTime(lockTime);
-	    SerializeUtils.signJSON(requestTO, clientKey);
-	    
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertFalse(responseTO.isSuccess());
-        assertNull(responseTO.timeLockedAddress());
-        assertEquals(responseTO.type(), Type.LOCKTIME_ERROR);
+					.currentDate(Utils.currentTimeMillis())
+					.publicKey(clientKey.getPubKey())
+					.lockTime(lockTime);
+		SerializeUtils.signJSON(requestTO, clientKey);
+
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertFalse(responseTO.isSuccess());
+		assertNull(responseTO.timeLockedAddress());
+		assertEquals(responseTO.type(), Type.LOCKTIME_ERROR);
 	}
 
 	@Test
@@ -323,83 +328,82 @@ public class PaymentControllerTest extends CoinbleskTest {
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testCreateTimeLockedAddress_RequestTwice() throws Exception {
 		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-		long lockTime = Utils.currentTimeSeconds()+100;
+		long lockTime = Utils.currentTimeSeconds() + 100;
 		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-		    		.currentDate(Utils.currentTimeMillis())
-		    		.publicKey(clientKey.getPubKey())
-		    		.lockTime(lockTime);
-	    SerializeUtils.signJSON(requestTO, clientKey);
-	    
-	    TimeLockedAddress address1, address2;
-	    // 1st request
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertTrue(responseTO.isSuccess());
-        assertNotNull(responseTO.timeLockedAddress());
-        assertEquals(responseTO.type(), Type.SUCCESS);
-        address1 = responseTO.timeLockedAddress();
-        assertVerifyJSONSig(responseTO, ECKey.fromPublicOnly(address1.getServerPubKey()));
-        
-        // 2nd request 
-        responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertTrue(responseTO.isSuccess());
-        assertNotNull(responseTO.timeLockedAddress());
-        assertEquals(responseTO.type(), Type.SUCCESS_BUT_ADDRESS_ALREADY_EXISTS);
-        address2 = responseTO.timeLockedAddress();
-        assertVerifyJSONSig(responseTO, ECKey.fromPublicOnly(address2.getServerPubKey()));
-        
-        // must receive same address
-        assertEquals(address1, address2);
+					.currentDate(Utils.currentTimeMillis())
+					.publicKey(clientKey.getPubKey())
+					.lockTime(lockTime);
+		SerializeUtils.signJSON(requestTO, clientKey);
+
+		TimeLockedAddress address1, address2;
+		// 1st request
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertTrue(responseTO.isSuccess());
+		assertNotNull(responseTO.timeLockedAddress());
+		assertEquals(responseTO.type(), Type.SUCCESS);
+		address1 = responseTO.timeLockedAddress();
+		assertVerifyJSONSig(responseTO, ECKey.fromPublicOnly(address1.getServerPubKey()));
+
+		// 2nd request
+		responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertTrue(responseTO.isSuccess());
+		assertNotNull(responseTO.timeLockedAddress());
+		assertEquals(responseTO.type(), Type.SUCCESS_BUT_ADDRESS_ALREADY_EXISTS);
+		address2 = responseTO.timeLockedAddress();
+		assertVerifyJSONSig(responseTO, ECKey.fromPublicOnly(address2.getServerPubKey()));
+
+		// must receive same address
+		assertEquals(address1, address2);
 	}
 
-    @Test
+	@Test
 	@DatabaseSetup("/EmptyDatabase.xml")
 	@DatabaseSetup("/keys.xml")
 	@DatabaseTearDown("/EmptyDatabase.xml")
-    public void testCreateTimeLockedAddress_NewAddress_ClientKnown() throws Exception {
-    	// keys are already stored in DB
-        ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-		ECKey serverKey = KeyTestUtil.ALICE_SERVER; 
-        
-        TimeLockedAddressTO requestTO = createSignedTimeLockedAddressTO(clientKey);
-        TimeLockedAddress expectedAddress = new TimeLockedAddress(
-        		clientKey.getPubKey(), serverKey.getPubKey(), requestTO.lockTime());
-        assertFalse(keyService.addressExists(expectedAddress.getAddressHash()));
-        
-        TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
-        assertTrue(responseTO.isSuccess());
-        assertVerifyJSONSig(responseTO, serverKey);
-        
-        
-    	TimeLockedAddress address = responseTO.timeLockedAddress();
-    	assertVerifyJSONSig(responseTO, ECKey.fromPublicOnly(address.getServerPubKey()));
-    	assertNotNull(address);
-    	assertNotNull(address.getAddressHash());
-    	assertNotNull(address.getClientPubKey());
-    	assertNotNull(address.getServerPubKey());
-    	assertTrue(BitcoinUtils.isLockTimeByTime(address.getLockTime()));
-    	
-    	assertArrayEquals(address.getClientPubKey(), clientKey.getPubKey());
-    	assertArrayEquals(address.getServerPubKey(), serverKey.getPubKey());
-    	assertEquals(address.getLockTime(), requestTO.lockTime());
-    	
-    	assertEquals(expectedAddress, address);
-    	assertTrue(keyService.addressExists(address.getAddressHash()));
-    }
-    
-    private TimeLockedAddressTO requestCreateTimeLockedAddress(TimeLockedAddressTO requestTO) throws Exception {
-    	String jsonTO = SerializeUtils.GSON.toJson(requestTO);
-        return RESTUtils.postRequest(mockMvc, URL_CREATE_TIME_LOCKED_ADDRESS, jsonTO, TimeLockedAddressTO.class);
-    }
-    
+	public void testCreateTimeLockedAddress_NewAddress_ClientKnown() throws Exception {
+		// keys are already stored in DB
+		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
+		ECKey serverKey = KeyTestUtil.ALICE_SERVER;
+
+		TimeLockedAddressTO requestTO = createSignedTimeLockedAddressTO(clientKey);
+		TimeLockedAddress expectedAddress = new TimeLockedAddress(
+				clientKey.getPubKey(), serverKey.getPubKey(), requestTO.lockTime());
+		assertFalse(keyService.addressExists(expectedAddress.getAddressHash()));
+
+		TimeLockedAddressTO responseTO = requestCreateTimeLockedAddress(requestTO);
+		assertTrue(responseTO.isSuccess());
+		assertVerifyJSONSig(responseTO, serverKey);
+
+		TimeLockedAddress address = responseTO.timeLockedAddress();
+		assertVerifyJSONSig(responseTO, ECKey.fromPublicOnly(address.getServerPubKey()));
+		assertNotNull(address);
+		assertNotNull(address.getAddressHash());
+		assertNotNull(address.getClientPubKey());
+		assertNotNull(address.getServerPubKey());
+		assertTrue(BitcoinUtils.isLockTimeByTime(address.getLockTime()));
+
+		assertArrayEquals(address.getClientPubKey(), clientKey.getPubKey());
+		assertArrayEquals(address.getServerPubKey(), serverKey.getPubKey());
+		assertEquals(address.getLockTime(), requestTO.lockTime());
+
+		assertEquals(expectedAddress, address);
+		assertTrue(keyService.addressExists(address.getAddressHash()));
+	}
+
+	private TimeLockedAddressTO requestCreateTimeLockedAddress(TimeLockedAddressTO requestTO) throws Exception {
+		String jsonTO = SerializeUtils.GSON.toJson(requestTO);
+		return RESTUtils.postRequest(mockMvc, URL_CREATE_TIME_LOCKED_ADDRESS, jsonTO, TimeLockedAddressTO.class);
+	}
+
 	private TimeLockedAddressTO createSignedTimeLockedAddressTO(ECKey clientKey) {
 		// lock time between now and (now+1year)
-		long lockTime = Utils.currentTimeSeconds() + new Random().nextInt(365*24*60*60);
+		long lockTime = Utils.currentTimeSeconds() + new Random().nextInt(365 * 24 * 60 * 60);
 		TimeLockedAddressTO requestTO = new TimeLockedAddressTO()
-	    		.currentDate(Utils.currentTimeMillis())
-	    		.publicKey(clientKey.getPubKey())
-	    		.lockTime(lockTime);
-	    SerializeUtils.signJSON(requestTO, clientKey);
-	    return requestTO;
+				.currentDate(Utils.currentTimeMillis())
+																	.publicKey(clientKey.getPubKey())
+																	.lockTime(lockTime);
+		SerializeUtils.signJSON(requestTO, clientKey);
+		return requestTO;
 	}
 
 	private static <K extends BaseTO<?>> boolean assertVerifyJSONSig(K k, ECKey key) {

--- a/src/test/java/com/coinblesk/server/controller/RegisterKeyTest.java
+++ b/src/test/java/com/coinblesk/server/controller/RegisterKeyTest.java
@@ -41,46 +41,46 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 public class RegisterKeyTest extends CoinbleskTest {
 
-    @Autowired
-    private WebApplicationContext webAppContext;
+	@Autowired
+	private WebApplicationContext webAppContext;
 
-    private static MockMvc mockMvc;
-    
-    @Before
-    public void setUp() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
-    }
+	private static MockMvc mockMvc;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testRegister() throws Exception {
-        //no object
-        mockMvc.perform(post("/p/x").secure(true)).andExpect(status().is4xxClientError());
-        //with object, but no public key
-        KeyTO keyTO = new KeyTO();
-        keyTO.currentDate(System.currentTimeMillis());
-        MvcResult res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON)
-                .content(SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
-        KeyTO status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
-        Assert.assertEquals(false, status.isSuccess());
-        Assert.assertEquals(Type.INPUT_MISMATCH, status.type());
-        Assert.assertNull(status.publicKey());
-        //with bogus key
-        keyTO = new KeyTO().publicKey("bogus=======".getBytes());
-        res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON).content(
-                SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
-        Assert.assertEquals(false, status.isSuccess());
-        Assert.assertEquals(Type.INPUT_MISMATCH, status.type());
-        Assert.assertNull(status.publicKey());
-        //with good pubilc key
-        ECKey ecKeyClient = new ECKey();
-        keyTO = new KeyTO().publicKey(ecKeyClient.getPubKey());
-        res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON).content(
-                SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
-        status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
-        Assert.assertEquals(true, status.isSuccess());
-        Assert.assertNotNull(status.publicKey());
-    }
+	@Before
+	public void setUp() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testRegister() throws Exception {
+		// no object
+		mockMvc.perform(post("/p/x").secure(true)).andExpect(status().is4xxClientError());
+		// with object, but no public key
+		KeyTO keyTO = new KeyTO();
+		keyTO.currentDate(System.currentTimeMillis());
+		MvcResult res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
+		KeyTO status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
+		Assert.assertEquals(false, status.isSuccess());
+		Assert.assertEquals(Type.INPUT_MISMATCH, status.type());
+		Assert.assertNull(status.publicKey());
+		// with bogus key
+		keyTO = new KeyTO().publicKey("bogus=======".getBytes());
+		res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+				SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
+		Assert.assertEquals(false, status.isSuccess());
+		Assert.assertEquals(Type.INPUT_MISMATCH, status.type());
+		Assert.assertNull(status.publicKey());
+		// with good pubilc key
+		ECKey ecKeyClient = new ECKey();
+		keyTO = new KeyTO().publicKey(ecKeyClient.getPubKey());
+		res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+				SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
+		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
+		Assert.assertEquals(true, status.isSuccess());
+		Assert.assertNotNull(status.publicKey());
+	}
 }

--- a/src/test/java/com/coinblesk/server/controller/RegisterKeyTest.java
+++ b/src/test/java/com/coinblesk/server/controller/RegisterKeyTest.java
@@ -15,12 +15,9 @@
  */
 package com.coinblesk.server.controller;
 
-import com.coinblesk.json.v1.KeyTO;
-import com.coinblesk.json.v1.Type;
-import com.coinblesk.server.utilTest.CoinbleskTest;
-import com.coinblesk.util.SerializeUtils;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.bitcoinj.core.ECKey;
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,8 +29,12 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.coinblesk.json.v1.KeyTO;
+import com.coinblesk.json.v1.Type;
+import com.coinblesk.server.utilTest.CoinbleskTest;
+import com.coinblesk.util.SerializeUtils;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 
 /**
  *
@@ -56,11 +57,11 @@ public class RegisterKeyTest extends CoinbleskTest {
 	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testRegister() throws Exception {
 		// no object
-		mockMvc.perform(post("/p/x").secure(true)).andExpect(status().is4xxClientError());
+		mockMvc.perform(post("/payment/key-exchange").secure(true)).andExpect(status().is4xxClientError());
 		// with object, but no public key
 		KeyTO keyTO = new KeyTO();
 		keyTO.currentDate(System.currentTimeMillis());
-		MvcResult res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON)
+		MvcResult res = mockMvc.perform(post("/payment/key-exchange").secure(true).contentType(MediaType.APPLICATION_JSON)
 				.content(SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
 		KeyTO status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
 		Assert.assertEquals(false, status.isSuccess());
@@ -68,7 +69,7 @@ public class RegisterKeyTest extends CoinbleskTest {
 		Assert.assertNull(status.publicKey());
 		// with bogus key
 		keyTO = new KeyTO().publicKey("bogus=======".getBytes());
-		res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+		res = mockMvc.perform(post("/payment/key-exchange").secure(true).contentType(MediaType.APPLICATION_JSON).content(
 				SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
 		Assert.assertEquals(false, status.isSuccess());
@@ -77,7 +78,7 @@ public class RegisterKeyTest extends CoinbleskTest {
 		// with good pubilc key
 		ECKey ecKeyClient = new ECKey();
 		keyTO = new KeyTO().publicKey(ecKeyClient.getPubKey());
-		res = mockMvc.perform(post("/p/x").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+		res = mockMvc.perform(post("/payment/key-exchange").secure(true).contentType(MediaType.APPLICATION_JSON).content(
 				SerializeUtils.GSON.toJson(keyTO))).andExpect(status().isOk()).andReturn();
 		status = SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), KeyTO.class);
 		Assert.assertEquals(true, status.isSuccess());

--- a/src/test/java/com/coinblesk/server/controller/SignTest.java
+++ b/src/test/java/com/coinblesk/server/controller/SignTest.java
@@ -51,119 +51,118 @@ import java.util.List;
  */
 public class SignTest extends CoinbleskTest {
 
-    @Autowired
-    private WebApplicationContext webAppContext;
+	@Autowired
+	private WebApplicationContext webAppContext;
 
-    @Autowired
-    private AppConfig appConfig;
+	@Autowired
+	private AppConfig appConfig;
 
-    @Autowired
-    private WalletService walletService;
+	@Autowired
+	private WalletService walletService;
 
-    private static MockMvc mockMvc;
+	private static MockMvc mockMvc;
 
-    private NetworkParameters params;
-    
-    @Before
-    public void setUp() throws Exception {
-        walletService.shutdown();
-        mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
-        walletService.init();
-        params = appConfig.getNetworkParameters();
-    }
+	private NetworkParameters params;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testAddressEmpty() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(123450), client.p2shAddress(),
-                walletService.blockChain());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date();
-        List<Pair<byte[], Long>> outpointCoinPair = client.outpointsRaw(funding);
-        SignTO prepareHalfSignTO = ServerCalls.signServerCallInput(outpointCoinPair,
-                new ECKey().toAddress(params), amountToRequest.value, client.ecKey(), now);
-        prepareHalfSignTO.p2shAddressTo("1");
-        SerializeUtils.signJSON(prepareHalfSignTO, client.ecKey());
-        SignTO status = ServerCalls.signServerCallOutput(mockMvc, prepareHalfSignTO);
-        Assert.assertFalse(status.isSuccess());
-        Assert.assertEquals(Type.ADDRESS_EMPTY, status.type());
-    }
+	@Before
+	public void setUp() throws Exception {
+		walletService.shutdown();
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+		walletService.init();
+		params = appConfig.getNetworkParameters();
+	}
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testAddressNotEnoughFunds() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(1), client.p2shAddress(),
-                walletService.blockChain());
-        Coin amountToRequest = Coin.valueOf(9876);
-        Date now = new Date();
-        SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
-                new ECKey().toAddress(params), amountToRequest.value, client, now);
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testAddressEmpty() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(123450), client.p2shAddress(),
+				walletService.blockChain());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date();
+		List<Pair<byte[], Long>> outpointCoinPair = client.outpointsRaw(funding);
+		SignTO prepareHalfSignTO = ServerCalls.signServerCallInput(outpointCoinPair,
+				new ECKey().toAddress(params), amountToRequest.value, client.ecKey(), now);
+		prepareHalfSignTO.p2shAddressTo("1");
+		SerializeUtils.signJSON(prepareHalfSignTO, client.ecKey());
+		SignTO status = ServerCalls.signServerCallOutput(mockMvc, prepareHalfSignTO);
+		Assert.assertFalse(status.isSuccess());
+		Assert.assertEquals(Type.ADDRESS_EMPTY, status.type());
+	}
 
-        Assert.assertFalse(status.isSuccess());
-        Assert.assertEquals(Type.NOT_ENOUGH_COINS, status.type());
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testAddressNotEnoughFunds() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(1), client.p2shAddress(),
+				walletService.blockChain());
+		Coin amountToRequest = Coin.valueOf(9876);
+		Date now = new Date();
+		SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
+				new ECKey().toAddress(params), amountToRequest.value, client, now);
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testAddressOnlyDust() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(700), client.p2shAddress(),
-                walletService.blockChain());
-        Coin amountToRequest = Coin.valueOf(100);
-        Date now = new Date();
-        SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
-                new ECKey().toAddress(params), amountToRequest.value, client, now);
-        Assert.assertFalse(status.isSuccess());
-        Assert.assertEquals(Type.TX_ERROR, status.type());
-    }
+		Assert.assertFalse(status.isSuccess());
+		Assert.assertEquals(Type.NOT_ENOUGH_COINS, status.type());
+	}
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @ExpectedDatabase(value = "/TxTwice.xml",
-            assertionMode = DatabaseAssertionMode.NON_STRICT_UNORDERED)
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testSignTwice() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(123450), client.p2shAddress(),
-                walletService.blockChain());
-        Date now = new Date();
-        Coin amountToRequest = Coin.valueOf(9876);
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testAddressOnlyDust() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(700), client.p2shAddress(),
+				walletService.blockChain());
+		Coin amountToRequest = Coin.valueOf(100);
+		Date now = new Date();
+		SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
+				new ECKey().toAddress(params), amountToRequest.value, client, now);
+		Assert.assertFalse(status.isSuccess());
+		Assert.assertEquals(Type.TX_ERROR, status.type());
+	}
 
-        SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
-                new ECKey().toAddress(params), amountToRequest.value, client, now);
-        Assert.assertTrue(status.isSuccess());
-        Date now2 = new Date(now.getTime() + 5000L);
-        status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
-                new ECKey().toAddress(params), amountToRequest.value, client, now2);
-        Assert.assertTrue(status.isSuccess());
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@ExpectedDatabase(value = "/TxTwice.xml", assertionMode = DatabaseAssertionMode.NON_STRICT_UNORDERED)
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testSignTwice() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(123450), client.p2shAddress(),
+				walletService.blockChain());
+		Date now = new Date();
+		Coin amountToRequest = Coin.valueOf(9876);
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testServerSignatures() throws Exception {
-        Client client = new Client(params, mockMvc);
-        Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(123450),
-                client.p2shAddress(), walletService.blockChain());
-        Date now = new Date();
-        Coin amountToRequest = Coin.valueOf(9876);
+		SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
+				new ECKey().toAddress(params), amountToRequest.value, client, now);
+		Assert.assertTrue(status.isSuccess());
+		Date now2 = new Date(now.getTime() + 5000L);
+		status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
+				new ECKey().toAddress(params), amountToRequest.value, client, now2);
+		Assert.assertTrue(status.isSuccess());
+	}
 
-        SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
-                new ECKey().toAddress(params), amountToRequest.value, client, now);
-        Assert.assertTrue(status.isSuccess());
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testServerSignatures() throws Exception {
+		Client client = new Client(params, mockMvc);
+		Transaction funding = Client.sendFakeCoins(params, Coin.valueOf(123450),
+				client.p2shAddress(), walletService.blockChain());
+		Date now = new Date();
+		Coin amountToRequest = Coin.valueOf(9876);
 
-        Transaction tx = new Transaction(params, status.transaction());
+		SignTO status = ServerCalls.signServerCall(mockMvc, client.outpointsRaw(funding),
+				new ECKey().toAddress(params), amountToRequest.value, client, now);
+		Assert.assertTrue(status.isSuccess());
 
-        List<TransactionSignature> sigs = SerializeUtils.deserializeSignatures(
-                status.signatures());
-        Assert.assertTrue(SerializeUtils.verifyTxSignatures(tx, sigs,
-                client.redeemScript(), client.ecKeyServer()));
-        Assert.assertFalse(SerializeUtils.verifyTxSignatures(tx, sigs,
-                client.redeemScript(), client.ecKey()));
-    }
+		Transaction tx = new Transaction(params, status.transaction());
+
+		List<TransactionSignature> sigs = SerializeUtils.deserializeSignatures(
+				status.signatures());
+		Assert.assertTrue(SerializeUtils.verifyTxSignatures(tx, sigs,
+				client.redeemScript(), client.ecKeyServer()));
+		Assert.assertFalse(SerializeUtils.verifyTxSignatures(tx, sigs,
+				client.redeemScript(), client.ecKey()));
+	}
 }

--- a/src/test/java/com/coinblesk/server/controller/VersionControllerTest.java
+++ b/src/test/java/com/coinblesk/server/controller/VersionControllerTest.java
@@ -39,127 +39,114 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 public class VersionControllerTest extends CoinbleskTest {
 	private static final String URL_VERSION = "/v1/version";
-	
+
 	private static final String SUPPORTED_CLIENT_VERSION;
 	static {
 		SUPPORTED_CLIENT_VERSION = new AppConfig().getSupportedClientVersions().iterator().next();
 	}
-	
-	private static final String UNSUPPORTED_CLIENT_VERSION = "not supported";
-	
-	@Autowired
-    private WebApplicationContext webAppContext;
 
-    private static MockMvc mockMvc;
-    
-    @Before
-    public void setUp() {
-         mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
-    }
-    
+	private static final String UNSUPPORTED_CLIENT_VERSION = "not supported";
+
+	@Autowired
+	private WebApplicationContext webAppContext;
+
+	private static MockMvc mockMvc;
+
+	@Before
+	public void setUp() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webAppContext).build();
+	}
+
 	@Test
 	public void testVersion_NoContent() throws Exception {
-		mockMvc
-			.perform(post(URL_VERSION).secure(true))
-			.andExpect(status().is4xxClientError());
+		mockMvc.perform(post(URL_VERSION).secure(true)).andExpect(status().is4xxClientError());
 	}
-	
+
 	@Test
 	public void testVersion_NoInputs() throws Exception {
 		VersionTO requestTO = new VersionTO();
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertFalse(responseTO.isSuccess());
 		assertFalse(responseTO.isSupported());
 		assertEquals(responseTO.type(), Type.INPUT_MISMATCH);
 	}
-	
+
 	@Test
 	public void testVersion_NoNetwork() throws Exception {
-		VersionTO requestTO = new VersionTO()
-				.clientVersion(SUPPORTED_CLIENT_VERSION);
-				// network missing
+		VersionTO requestTO = new VersionTO().clientVersion(SUPPORTED_CLIENT_VERSION);
+		// network missing
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertFalse(responseTO.isSuccess());
 		assertFalse(responseTO.isSupported());
 		assertEquals(responseTO.type(), Type.INPUT_MISMATCH);
 	}
-	
+
 	@Test
 	public void testVersion_NoClientVersion() throws Exception {
 		VersionTO requestTO = new VersionTO()
 				// client version missing
 				.bitcoinNet(BitcoinNet.UNITTEST);
-				
+
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertFalse(responseTO.isSuccess());
 		assertFalse(responseTO.isSupported());
 		assertEquals(responseTO.type(), Type.INPUT_MISMATCH);
 	}
-	
+
 	@Test
 	public void testVersion_SupportedVersion_SameNetwork() throws Exception {
-		VersionTO requestTO = new VersionTO()
-				.clientVersion(SUPPORTED_CLIENT_VERSION)
-				.bitcoinNet(BitcoinNet.UNITTEST);
-		
+		VersionTO requestTO = new VersionTO().clientVersion(SUPPORTED_CLIENT_VERSION).bitcoinNet(BitcoinNet.UNITTEST);
+
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertTrue(responseTO.isSuccess());
 		assertTrue(responseTO.isSupported());
 		assertEquals(responseTO.bitcoinNet(), BitcoinNet.UNITTEST);
 		assertEquals(responseTO.type(), Type.SUCCESS);
 	}
-	
+
 	@Test
 	public void testVersion_SupportedVersion_DifferentNetwork() throws Exception {
-		VersionTO requestTO = new VersionTO()
-				.clientVersion(SUPPORTED_CLIENT_VERSION)
-				.bitcoinNet(BitcoinNet.MAINNET);
-		
+		VersionTO requestTO = new VersionTO().clientVersion(SUPPORTED_CLIENT_VERSION).bitcoinNet(BitcoinNet.MAINNET);
+
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertTrue(responseTO.isSuccess());
 		assertFalse(responseTO.isSupported());
 		assertEquals(responseTO.bitcoinNet(), BitcoinNet.UNITTEST);
 		assertEquals(responseTO.type(), Type.SUCCESS);
 	}
-	
+
 	@Test
 	public void testVersion_UnsupportedVersion_SameNetwork() throws Exception {
-		VersionTO requestTO = new VersionTO()
-			.clientVersion(UNSUPPORTED_CLIENT_VERSION)
-			.bitcoinNet(BitcoinNet.UNITTEST);
+		VersionTO requestTO = new VersionTO().clientVersion(UNSUPPORTED_CLIENT_VERSION).bitcoinNet(BitcoinNet.UNITTEST);
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertTrue(responseTO.isSuccess());
 		assertFalse(responseTO.isSupported());
 		assertEquals(responseTO.bitcoinNet(), BitcoinNet.UNITTEST);
 		assertEquals(responseTO.type(), Type.SUCCESS);
 	}
-	
-	
-	
+
 	@Test
 	public void testVersion_UnsupportedVersion_DifferentNetwork() throws Exception {
-		VersionTO requestTO = new VersionTO()
-			.clientVersion(UNSUPPORTED_CLIENT_VERSION)
-			.bitcoinNet(BitcoinNet.MAINNET);
+		VersionTO requestTO = new VersionTO().clientVersion(UNSUPPORTED_CLIENT_VERSION).bitcoinNet(BitcoinNet.MAINNET);
 		VersionTO responseTO = RESTUtils.postRequest(mockMvc, URL_VERSION, requestTO);
-		
+
 		assertNotNull(responseTO);
 		assertTrue(responseTO.isSuccess());
 		assertFalse(responseTO.isSupported());
 		assertEquals(responseTO.bitcoinNet(), BitcoinNet.UNITTEST);
 		assertEquals(responseTO.type(), Type.SUCCESS);
 	}
-	
+
 }

--- a/src/test/java/com/coinblesk/server/service/ForexExchangeRateServiceTest.java
+++ b/src/test/java/com/coinblesk/server/service/ForexExchangeRateServiceTest.java
@@ -25,29 +25,29 @@ import java.util.Map;
 
 public class ForexExchangeRateServiceTest extends CoinbleskTest {
 
-    @Autowired
-    private ForexService forexExchangeRateService;
-    
-    @Test
-    public void testForex() throws Exception {
-        BigDecimal d = forexExchangeRateService.getExchangeRate("USD", "CHF");
-        Assert.assertNotNull(d);
-        System.out.println("rate is: " + d);
-    }
+	@Autowired
+	private ForexService forexExchangeRateService;
 
-    @Test
-    public void testForexMulti1() throws Exception {
-        Map<String, BigDecimal> m = forexExchangeRateService.getExchangeRates("CHFUSD", "USDEUR");
-        Assert.assertNotNull(m);
-        System.out.println("rate is: " + m);
-    }
+	@Test
+	public void testForex() throws Exception {
+		BigDecimal d = forexExchangeRateService.getExchangeRate("USD", "CHF");
+		Assert.assertNotNull(d);
+		System.out.println("rate is: " + d);
+	}
 
-    @Test
-    public void testForexMulti2() throws Exception {
-        //TODO: check if cached
-        Map<String, BigDecimal> m = forexExchangeRateService.getExchangeRates("CHFUSD", "USDEUR");
-        Assert.assertNotNull(m);
-        System.out.println("rate is: " + m);
-    }
+	@Test
+	public void testForexMulti1() throws Exception {
+		Map<String, BigDecimal> m = forexExchangeRateService.getExchangeRates("CHFUSD", "USDEUR");
+		Assert.assertNotNull(m);
+		System.out.println("rate is: " + m);
+	}
+
+	@Test
+	public void testForexMulti2() throws Exception {
+		// TODO: check if cached
+		Map<String, BigDecimal> m = forexExchangeRateService.getExchangeRates("CHFUSD", "USDEUR");
+		Assert.assertNotNull(m);
+		System.out.println("rate is: " + m);
+	}
 
 }

--- a/src/test/java/com/coinblesk/server/service/KeyServiceTest.java
+++ b/src/test/java/com/coinblesk/server/service/KeyServiceTest.java
@@ -38,118 +38,117 @@ import static org.junit.Assert.*;
  * @author Thomas Bocek
  * @author Andreas Albrecht
  */
-@TestExecutionListeners( listeners = DbUnitTestExecutionListener.class,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(listeners = DbUnitTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class KeyServiceTest extends CoinbleskTest {
-    
-    @Autowired
-    private KeyService keyService;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testAddKey() throws Exception {
-        ECKey ecKeyClient = new ECKey();
-        ECKey ecKeyServer = new ECKey();
+	@Autowired
+	private KeyService keyService;
 
-        boolean retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
-                ecKeyServer.getPrivKeyBytes()).element0();
-        Assert.assertTrue(retVal);
-        //adding again should fail
-        retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(), ecKeyServer
-                .getPrivKeyBytes()).element0();
-        Assert.assertFalse(retVal);
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testAddKey() throws Exception {
+		ECKey ecKeyClient = new ECKey();
+		ECKey ecKeyServer = new ECKey();
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testAddKey2() throws Exception {
-        ECKey ecKeyClient = new ECKey();
-        ECKey ecKeyServer = new ECKey();
+		boolean retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
+				ecKeyServer.getPrivKeyBytes()).element0();
+		Assert.assertTrue(retVal);
+		// adding again should fail
+		retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
+				ecKeyServer.getPrivKeyBytes()).element0();
+		Assert.assertFalse(retVal);
+	}
 
-        boolean retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
-                ecKeyServer.getPrivKeyBytes()).element0();
-        Assert.assertTrue(retVal);
-        retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(), ecKeyServer
-                .getPrivKeyBytes()).element0();
-        Assert.assertFalse(retVal);
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testAddKey2() throws Exception {
+		ECKey ecKeyClient = new ECKey();
+		ECKey ecKeyServer = new ECKey();
 
-        Keys keys = keyService.getByClientPublicKey(ecKeyClient.getPubKey());
-        Assert.assertNotNull(keys);
+		boolean retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
+				ecKeyServer.getPrivKeyBytes()).element0();
+		Assert.assertTrue(retVal);
+		retVal = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
+				ecKeyServer.getPrivKeyBytes()).element0();
+		Assert.assertFalse(retVal);
 
-        keys = keyService.getByClientPublicKey(ecKeyClient.getPubKey());
-        Assert.assertNotNull(keys);
-        //
-        List<ECKey> list = keyService.getPublicECKeysByClientPublicKey(ecKeyClient.getPubKey());
-        Assert.assertEquals(2, list.size());
-        Assert.assertArrayEquals(list.get(0).getPubKey(), ecKeyClient.getPubKey());
-        Assert.assertArrayEquals(list.get(1).getPubKey(), ecKeyServer.getPubKey());
-    }
+		Keys keys = keyService.getByClientPublicKey(ecKeyClient.getPubKey());
+		Assert.assertNotNull(keys);
 
-    
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseSetup("/keys.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
+		keys = keyService.getByClientPublicKey(ecKeyClient.getPubKey());
+		Assert.assertNotNull(keys);
+		//
+		List<ECKey> list = keyService.getPublicECKeysByClientPublicKey(ecKeyClient.getPubKey());
+		Assert.assertEquals(2, list.size());
+		Assert.assertArrayEquals(list.get(0).getPubKey(), ecKeyClient.getPubKey());
+		Assert.assertArrayEquals(list.get(1).getPubKey(), ecKeyServer.getPubKey());
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseSetup("/keys.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
 	public void testGetTimeLockedAddress_EmptyResult() {
 		long lockTime = 123456;
 		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-		
+
 		Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-		
+
 		TimeLockedAddress address = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), lockTime);
 		// do not store -> empty result
-		
-		TimeLockedAddressEntity fromDB  = keyService.getTimeLockedAddressByAddressHash(address.getAddressHash());
+
+		TimeLockedAddressEntity fromDB = keyService.getTimeLockedAddressByAddressHash(address.getAddressHash());
 		assertNull(fromDB);
 	}
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseSetup("/keys.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testStoreAndGetTimeLockedAddress() {
-    	long lockTime = 123456;
-    	ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-    	
-    	Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-    	
-    	TimeLockedAddress address = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), lockTime);
-    	TimeLockedAddressEntity intoDB = keyService.storeTimeLockedAddress(keys, address);
-    	assertNotNull(intoDB);
-    	
-    	TimeLockedAddressEntity fromDB  = keyService.getTimeLockedAddressByAddressHash(address.getAddressHash());
-    	assertNotNull(fromDB);
-    	assertEquals(intoDB, fromDB);
-    	
-    	keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-    	assertTrue(keys.timeLockedAddresses().contains(fromDB));
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseSetup("/keys.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testStoreAndGetTimeLockedAddress() {
+		long lockTime = 123456;
+		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseSetup("/keys.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testStoreAndGetTimeLockedAddresses() {
-    	ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
-    	
-    	Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-    	
-    	TimeLockedAddress address_1 = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), 42);
-    	TimeLockedAddress address_2 = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), 4242);
-    	TimeLockedAddressEntity addressEntity_1 = keyService.storeTimeLockedAddress(keys, address_1);
-		assertNotNull( addressEntity_1 );
-    	TimeLockedAddressEntity addressEntity_2 = keyService.storeTimeLockedAddress(keys, address_2);
-		assertNotNull( addressEntity_2 );
-    	
-    	List<TimeLockedAddressEntity> fromDB  = keyService.getTimeLockedAddressesByClientPublicKey(clientKey.getPubKey());
-    	assertNotNull(fromDB);
-    	assertTrue(fromDB.size() == 2);
-    	assertTrue(fromDB.contains(addressEntity_1));
-    	assertTrue(fromDB.contains(addressEntity_2));
-    	
-    	keys = keyService.getByClientPublicKey(clientKey.getPubKey());
-    	assertTrue(keys.timeLockedAddresses().containsAll(fromDB));
-    }
+		Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+
+		TimeLockedAddress address = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), lockTime);
+		TimeLockedAddressEntity intoDB = keyService.storeTimeLockedAddress(keys, address);
+		assertNotNull(intoDB);
+
+		TimeLockedAddressEntity fromDB = keyService.getTimeLockedAddressByAddressHash(address.getAddressHash());
+		assertNotNull(fromDB);
+		assertEquals(intoDB, fromDB);
+
+		keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+		assertTrue(keys.timeLockedAddresses().contains(fromDB));
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseSetup("/keys.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testStoreAndGetTimeLockedAddresses() {
+		ECKey clientKey = KeyTestUtil.ALICE_CLIENT;
+
+		Keys keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+
+		TimeLockedAddress address_1 = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), 42);
+		TimeLockedAddress address_2 = new TimeLockedAddress(clientKey.getPubKey(), keys.serverPublicKey(), 4242);
+		TimeLockedAddressEntity addressEntity_1 = keyService.storeTimeLockedAddress(keys, address_1);
+		assertNotNull(addressEntity_1);
+		TimeLockedAddressEntity addressEntity_2 = keyService.storeTimeLockedAddress(keys, address_2);
+		assertNotNull(addressEntity_2);
+
+		List<TimeLockedAddressEntity> fromDB = keyService.getTimeLockedAddressesByClientPublicKey(
+				clientKey.getPubKey());
+		assertNotNull(fromDB);
+		assertTrue(fromDB.size() == 2);
+		assertTrue(fromDB.contains(addressEntity_1));
+		assertTrue(fromDB.contains(addressEntity_2));
+
+		keys = keyService.getByClientPublicKey(clientKey.getPubKey());
+		assertTrue(keys.timeLockedAddresses().containsAll(fromDB));
+	}
 }

--- a/src/test/java/com/coinblesk/server/service/UserAccountServiceTest.java
+++ b/src/test/java/com/coinblesk/server/service/UserAccountServiceTest.java
@@ -5,17 +5,16 @@
  */
 package com.coinblesk.server.service;
 
-import com.coinblesk.bitcoin.TimeLockedAddress;
-import com.coinblesk.json.v1.UserAccountTO;
-import com.coinblesk.server.config.AppConfig;
-import com.coinblesk.server.entity.Keys;
-import com.coinblesk.server.entity.UserAccount;
-import com.coinblesk.server.utilTest.CoinbleskTest;
-import com.coinblesk.server.utilTest.FakeTxBuilder;
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
-import org.bitcoinj.core.*;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+import org.bitcoinj.core.Block;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.PrunedException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.wallet.UnreadableWalletException;
@@ -29,10 +28,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.TestExecutionListeners;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.Date;
-import java.util.List;
+import com.coinblesk.bitcoin.TimeLockedAddress;
+import com.coinblesk.json.v1.UserAccountTO;
+import com.coinblesk.server.config.AppConfig;
+import com.coinblesk.server.entity.Keys;
+import com.coinblesk.server.entity.UserAccount;
+import com.coinblesk.server.utilTest.CoinbleskTest;
+import com.coinblesk.server.utilTest.FakeTxBuilder;
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 
 /**
  *
@@ -74,13 +79,14 @@ public class UserAccountServiceTest extends CoinbleskTest {
 		}
 
 		UserAccount userAccount = new UserAccount();
-		userAccount	.setBalance(BigDecimal.ONE)
-					.setCreationDate(new Date(1))
-					.setDeleted(false)
-					.setEmail("test@test.test")
-					.setEmailToken(null)
-					.setPassword(passwordEncoder.encode("test"))
-					.setUsername("blib");
+		userAccount
+				.setBalance(BigDecimal.ONE)
+				.setCreationDate(new Date(1))
+				.setDeleted(false)
+				.setEmail("test@test.test")
+				.setEmailToken(null)
+				.setPassword(passwordEncoder.encode("test"))
+				.setUsername("blib");
 		userAccountService.save(userAccount);
 
 		Keys keys = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),

--- a/src/test/java/com/coinblesk/server/service/UserAccountServiceTest.java
+++ b/src/test/java/com/coinblesk/server/service/UserAccountServiceTest.java
@@ -38,83 +38,83 @@ import java.util.List;
  *
  * @author Thomas Bocek
  */
-@TestExecutionListeners( listeners = DbUnitTestExecutionListener.class,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(listeners = DbUnitTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class UserAccountServiceTest extends CoinbleskTest {
-    @MockBean
-    private MailService mailService;
+	@MockBean
+	private MailService mailService;
 
-    @Autowired
-    private UserAccountService userAccountService;
-    
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-    
-    @Autowired
-    private TxQueueService txQueueService;
-    
-    @Autowired
-    private KeyService keyService;
-    
-    @Autowired
-    private WalletService walletService;
-    
-    @Autowired
-    private AppConfig cfg;
+	@Autowired
+	private UserAccountService userAccountService;
 
-    final private ECKey ecKeyClient = new ECKey();
-    final private ECKey ecKeyServer = new ECKey();
-    
-    private int counter = 0;
+	@Autowired
+	private PasswordEncoder passwordEncoder;
 
-    @Before
-    public void before() throws IOException, UnreadableWalletException, BlockStoreException, InterruptedException {
-        System.setProperty("coinblesk.config.dir", "/tmp/lib/coinblesk" + (counter++));
-        if(counter > 0) {
-            walletService.init();
-        }
+	@Autowired
+	private TxQueueService txQueueService;
 
-        UserAccount userAccount = new UserAccount();
-        userAccount.setBalance(BigDecimal.ONE)
-                .setCreationDate(new Date(1))
-                .setDeleted(false)
-                .setEmail("test@test.test")
-                .setEmailToken(null)
-                .setPassword(passwordEncoder.encode("test"))
-                .setUsername("blib");
-        userAccountService.save(userAccount);
-        
-        Keys keys = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
-                ecKeyServer.getPrivKeyBytes()).element1();
-        
-        TimeLockedAddress address = new TimeLockedAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(), 123456);
-        
-        keyService.storeTimeLockedAddress(keys, address);
-    }
-    
-    @After
-    public void after() {
-        walletService.shutdown();
-    }
+	@Autowired
+	private KeyService keyService;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testTransferFailed() {
-        UserAccountTO result = userAccountService.transferP2SH(ecKeyClient, "test@test.test");
-        Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
-        Assert.assertFalse(result.isSuccess());
-    }
-    
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testTransferSuccess() throws BlockStoreException, VerificationException, PrunedException {
-        Block block = FakeTxBuilder.makeSolvedTestBlock(walletService.blockChain().getBlockStore(), cfg.getPotPrivateKeyAddress().toAddress(cfg.getNetworkParameters()));
-        walletService.blockChain().add(block);
-        UserAccountTO result = userAccountService.transferP2SH(ecKeyClient, "test@test.test");
-        Assert.assertTrue(result.isSuccess());
-        List<Transaction> list = txQueueService.all(UnitTestParams.get());
-        Assert.assertEquals(1, list.size());
-    }
+	@Autowired
+	private WalletService walletService;
+
+	@Autowired
+	private AppConfig cfg;
+
+	final private ECKey ecKeyClient = new ECKey();
+	final private ECKey ecKeyServer = new ECKey();
+
+	private int counter = 0;
+
+	@Before
+	public void before() throws IOException, UnreadableWalletException, BlockStoreException, InterruptedException {
+		System.setProperty("coinblesk.config.dir", "/tmp/lib/coinblesk" + (counter++));
+		if (counter > 0) {
+			walletService.init();
+		}
+
+		UserAccount userAccount = new UserAccount();
+		userAccount	.setBalance(BigDecimal.ONE)
+					.setCreationDate(new Date(1))
+					.setDeleted(false)
+					.setEmail("test@test.test")
+					.setEmailToken(null)
+					.setPassword(passwordEncoder.encode("test"))
+					.setUsername("blib");
+		userAccountService.save(userAccount);
+
+		Keys keys = keyService.storeKeysAndAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(),
+				ecKeyServer.getPrivKeyBytes()).element1();
+
+		TimeLockedAddress address = new TimeLockedAddress(ecKeyClient.getPubKey(), ecKeyServer.getPubKey(), 123456);
+
+		keyService.storeTimeLockedAddress(keys, address);
+	}
+
+	@After
+	public void after() {
+		walletService.shutdown();
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testTransferFailed() {
+		UserAccountTO result = userAccountService.transferP2SH(ecKeyClient, "test@test.test");
+		Mockito.verify(mailService, Mockito.times(1)).sendAdminMail(Mockito.anyString(), Mockito.anyString());
+		Assert.assertFalse(result.isSuccess());
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testTransferSuccess() throws BlockStoreException, VerificationException, PrunedException {
+		Block block = FakeTxBuilder.makeSolvedTestBlock(walletService.blockChain().getBlockStore(),
+				cfg.getPotPrivateKeyAddress().toAddress(cfg.getNetworkParameters()));
+		walletService.blockChain().add(block);
+		UserAccountTO result = userAccountService.transferP2SH(ecKeyClient, "test@test.test");
+		Assert.assertTrue(result.isSuccess());
+		List<Transaction> list = txQueueService.all(UnitTestParams.get());
+		Assert.assertEquals(1, list.size());
+	}
 }

--- a/src/test/java/com/coinblesk/server/service/UserTest.java
+++ b/src/test/java/com/coinblesk/server/service/UserTest.java
@@ -34,38 +34,36 @@ import java.util.Date;
  *
  * @author Thomas Bocek
  */
-@TestExecutionListeners( listeners = DbUnitTestExecutionListener.class,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(listeners = DbUnitTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class UserTest extends CoinbleskTest {
 
-    @Autowired
-    private UserAccountService userAccountService;
-    
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @ExpectedDatabase(value = "/UserTestAddUser.xml",
-            assertionMode = DatabaseAssertionMode.NON_STRICT_UNORDERED)
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testAddUser() throws Exception {
-        UserAccount userAccount = new UserAccount();
-        userAccount.setBalance(BigDecimal.ONE)
-                .setCreationDate(new Date(1))
-                .setDeleted(false)
-                .setEmail("test@test.test")
-                .setEmailToken(null)
-                .setPassword("blub")
-                .setUsername("blib");
-        userAccountService.save(userAccount);
-    }
+	@Autowired
+	private UserAccountService userAccountService;
 
-    @Test
-    @DatabaseSetup("/EmptyDatabase.xml")
-    @DatabaseSetup("/UserTestGetUser.xml")
-    @DatabaseTearDown("/EmptyDatabase.xml")
-    public void testGetUser() throws Exception {
-        UserAccount u1 = userAccountService.getByEmail("test");
-        Assert.assertNull(u1);
-        UserAccount u2 = userAccountService.getByEmail("test@test.test");
-        Assert.assertEquals("blub", u2.getPassword());
-    }
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@ExpectedDatabase(value = "/UserTestAddUser.xml", assertionMode = DatabaseAssertionMode.NON_STRICT_UNORDERED)
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testAddUser() throws Exception {
+		UserAccount userAccount = new UserAccount();
+		userAccount.setBalance(BigDecimal.ONE)
+			.setCreationDate(new Date(1))
+			.setDeleted(false)
+			.setEmail("test@test.test")
+			.setEmailToken(null)
+			.setPassword("blub")
+			.setUsername("blib");
+		userAccountService.save(userAccount);
+	}
+
+	@Test
+	@DatabaseSetup("/EmptyDatabase.xml")
+	@DatabaseSetup("/UserTestGetUser.xml")
+	@DatabaseTearDown("/EmptyDatabase.xml")
+	public void testGetUser() throws Exception {
+		UserAccount u1 = userAccountService.getByEmail("test");
+		Assert.assertNull(u1);
+		UserAccount u2 = userAccountService.getByEmail("test@test.test");
+		Assert.assertEquals("blub", u2.getPassword());
+	}
 }

--- a/src/test/java/com/coinblesk/server/utilTest/Client.java
+++ b/src/test/java/com/coinblesk/server/utilTest/Client.java
@@ -15,12 +15,28 @@
  */
 package com.coinblesk.server.utilTest;
 
-import com.coinblesk.json.v1.KeyTO;
-import com.coinblesk.util.BitcoinUtils;
-import com.coinblesk.util.Pair;
-import com.coinblesk.util.SerializeUtils;
-import com.google.common.io.Files;
-import org.bitcoinj.core.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Block;
+import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.PrunedException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.net.discovery.PeerDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscoveryException;
@@ -31,16 +47,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.io.File;
-import java.io.FilenameFilter;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.coinblesk.json.v1.KeyTO;
+import com.coinblesk.util.BitcoinUtils;
+import com.coinblesk.util.Pair;
+import com.coinblesk.util.SerializeUtils;
+import com.google.common.io.Files;
 
 /**
  *
@@ -148,7 +159,7 @@ public class Client {
 
 	private ECKey register(ECKey ecKeyClient, MockMvc mockMvc) throws Exception {
 		KeyTO keyTO = new KeyTO().publicKey(ecKeyClient.getPubKey());
-		MvcResult res = mockMvc.perform(post("/p/x")
+		MvcResult res = mockMvc.perform(post("/payment/key-exchange")
 				.secure(true)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(SerializeUtils.GSON.toJson(keyTO)))
@@ -198,7 +209,7 @@ public class Client {
 
 	public static Transaction sendFakeCoins(NetworkParameters params, Coin amount, Address to, BlockChain... chains)
 			throws VerificationException, PrunedException, BlockStoreException, InterruptedException {
-		
+
 		Transaction tx = FakeTxBuilder.createFakeTx(params, amount, to);
 		if (chains.length == 0) {
 			return tx;

--- a/src/test/java/com/coinblesk/server/utilTest/CoinbleskTest.java
+++ b/src/test/java/com/coinblesk/server/utilTest/CoinbleskTest.java
@@ -9,8 +9,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
-@TestExecutionListeners( listeners = DbUnitTestExecutionListener.class,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(listeners = DbUnitTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @ActiveProfiles("dev")
 public abstract class CoinbleskTest {
 }

--- a/src/test/java/com/coinblesk/server/utilTest/FakeTxBuilder.java
+++ b/src/test/java/com/coinblesk/server/utilTest/FakeTxBuilder.java
@@ -17,7 +17,6 @@ package com.coinblesk.server.utilTest;
  * limitations under the License.
  */
 
-
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.ScriptBuilder;
@@ -34,302 +33,326 @@ import static org.bitcoinj.core.Coin.COIN;
 import static org.bitcoinj.core.Coin.valueOf;
 
 public class FakeTxBuilder {
-    /** Create a fake transaction, without change. */
-    public static Transaction createFakeTx(final NetworkParameters params) {
-        return createFakeTxWithoutChangeAddress(params, Coin.COIN, new ECKey().toAddress(params));
-    }
+	/** Create a fake transaction, without change. */
+	public static Transaction createFakeTx(final NetworkParameters params) {
+		return createFakeTxWithoutChangeAddress(params, Coin.COIN, new ECKey().toAddress(params));
+	}
 
-    /** Create a fake transaction, without change. */
-    public static Transaction createFakeTxWithoutChange(final NetworkParameters params, final TransactionOutput output) {
-        Transaction prevTx = FakeTxBuilder.createFakeTx(params, Coin.COIN, new ECKey().toAddress(params));
-        Transaction tx = new Transaction(params);
-        tx.addOutput(output);
-        tx.addInput(prevTx.getOutput(0));
-        return tx;
-    }
+	/** Create a fake transaction, without change. */
+	public static Transaction createFakeTxWithoutChange(final NetworkParameters params,
+			final TransactionOutput output) {
+		Transaction prevTx = FakeTxBuilder.createFakeTx(params, Coin.COIN, new ECKey().toAddress(params));
+		Transaction tx = new Transaction(params);
+		tx.addOutput(output);
+		tx.addInput(prevTx.getOutput(0));
+		return tx;
+	}
 
-    /** Create a fake coinbase transaction. */
-    public static Transaction createFakeCoinbaseTx(final NetworkParameters params) {
-        TransactionOutPoint outpoint = new TransactionOutPoint(params, -1, Sha256Hash.ZERO_HASH);
-        TransactionInput input = new TransactionInput(params, null, new byte[0], outpoint);
-        Transaction tx = new Transaction(params);
-        tx.addInput(input);
-        TransactionOutput outputToMe = new TransactionOutput(params, tx, Coin.FIFTY_COINS,
-                new ECKey().toAddress(params));
-        tx.addOutput(outputToMe);
+	/** Create a fake coinbase transaction. */
+	public static Transaction createFakeCoinbaseTx(final NetworkParameters params) {
+		TransactionOutPoint outpoint = new TransactionOutPoint(params, -1, Sha256Hash.ZERO_HASH);
+		TransactionInput input = new TransactionInput(params, null, new byte[0], outpoint);
+		Transaction tx = new Transaction(params);
+		tx.addInput(input);
+		TransactionOutput outputToMe = new TransactionOutput(params, tx, Coin.FIFTY_COINS,
+				new ECKey().toAddress(params));
+		tx.addOutput(outputToMe);
 
-        checkState(tx.isCoinBase());
-        return tx;
-    }
-    
-    /** Create a fake coinbase transaction. */
-    public static Transaction createFakeCoinbaseTx(final NetworkParameters params, ECKey output) {
-        TransactionOutPoint outpoint = new TransactionOutPoint(params, -1, Sha256Hash.ZERO_HASH);
-        TransactionInput input = new TransactionInput(params, null, new byte[0], outpoint);
-        Transaction tx = new Transaction(params);
-        tx.addInput(input);
-        TransactionOutput outputToMe = new TransactionOutput(params, tx, Coin.FIFTY_COINS,
-                output.toAddress(params));
-        tx.addOutput(outputToMe);
+		checkState(tx.isCoinBase());
+		return tx;
+	}
 
-        checkState(tx.isCoinBase());
-        return tx;
-    }
+	/** Create a fake coinbase transaction. */
+	public static Transaction createFakeCoinbaseTx(final NetworkParameters params, ECKey output) {
+		TransactionOutPoint outpoint = new TransactionOutPoint(params, -1, Sha256Hash.ZERO_HASH);
+		TransactionInput input = new TransactionInput(params, null, new byte[0], outpoint);
+		Transaction tx = new Transaction(params);
+		tx.addInput(input);
+		TransactionOutput outputToMe = new TransactionOutput(params, tx, Coin.FIFTY_COINS, output.toAddress(params));
+		tx.addOutput(outputToMe);
 
-    /**
-     * Create a fake TX of sufficient realism to exercise the unit tests. Two outputs, one to us, one to somewhere
-     * else to simulate change. There is one random input.
-     */
-    public static Transaction createFakeTxWithChangeAddress(NetworkParameters params, Coin value, Address to, Address changeOutput) {
-        Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
-        t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), changeOutput);
-        t.addOutput(change);
-        // Make a previous tx simply to send us sufficient coins. This prev tx is not really valid but it doesn't
-        // matter for our purposes.
-        Transaction prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
-        prevTx.addOutput(prevOut);
-        // Connect it.
-        t.addInput(prevOut).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
-        // Fake signature.
-        // Serialize/deserialize to ensure internal state is stripped, as if it had been read from the wire.
-        return roundTripTransaction(params, t);
-    }
+		checkState(tx.isCoinBase());
+		return tx;
+	}
 
-    /**
-     * Create a fake TX for unit tests, for use with unit tests that need greater control. One outputs, 2 random inputs,
-     * split randomly to create randomness.
-     */
-    public static Transaction createFakeTxWithoutChangeAddress(NetworkParameters params, Coin value, Address to) {
-        Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
-        t.addOutput(outputToMe);
+	/**
+	 * Create a fake TX of sufficient realism to exercise the unit tests. Two
+	 * outputs, one to us, one to somewhere else to simulate change. There is
+	 * one random input.
+	 */
+	public static Transaction createFakeTxWithChangeAddress(NetworkParameters params, Coin value, Address to,
+			Address changeOutput) {
+		Transaction t = new Transaction(params);
+		TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+		t.addOutput(outputToMe);
+		TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), changeOutput);
+		t.addOutput(change);
+		// Make a previous tx simply to send us sufficient coins. This prev tx
+		// is not really valid but it doesn't
+		// matter for our purposes.
+		Transaction prevTx = new Transaction(params);
+		TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
+		prevTx.addOutput(prevOut);
+		// Connect it.
+		t.addInput(prevOut).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+		// Fake signature.
+		// Serialize/deserialize to ensure internal state is stripped, as if it
+		// had been read from the wire.
+		return roundTripTransaction(params, t);
+	}
 
-        // Make a random split in the output value so we get a distinct hash when we call this multiple times with same args
-        long split = new Random().nextLong();
-        if (split < 0) { split *= -1; }
-        if (split == 0) { split = 15; }
-        while (split > value.getValue()) {
-            split /= 2;
-        }
+	/**
+	 * Create a fake TX for unit tests, for use with unit tests that need
+	 * greater control. One outputs, 2 random inputs, split randomly to create
+	 * randomness.
+	 */
+	public static Transaction createFakeTxWithoutChangeAddress(NetworkParameters params, Coin value, Address to) {
+		Transaction t = new Transaction(params);
+		TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+		t.addOutput(outputToMe);
 
-        // Make a previous tx simply to send us sufficient coins. This prev tx is not really valid but it doesn't
-        // matter for our purposes.
-        Transaction prevTx1 = new Transaction(params);
-        TransactionOutput prevOut1 = new TransactionOutput(params, prevTx1, Coin.valueOf(split), to);
-        prevTx1.addOutput(prevOut1);
-        // Connect it.
-        t.addInput(prevOut1).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
-        // Fake signature.
+		// Make a random split in the output value so we get a distinct hash
+		// when we call this multiple times with same args
+		long split = new Random().nextLong();
+		if (split < 0) {
+			split *= -1;
+		}
+		if (split == 0) {
+			split = 15;
+		}
+		while (split > value.getValue()) {
+			split /= 2;
+		}
 
-        // Do it again
-        Transaction prevTx2 = new Transaction(params);
-        TransactionOutput prevOut2 = new TransactionOutput(params, prevTx2, Coin.valueOf(value.getValue() - split), to);
-        prevTx2.addOutput(prevOut2);
-        t.addInput(prevOut2).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+		// Make a previous tx simply to send us sufficient coins. This prev tx
+		// is not really valid but it doesn't
+		// matter for our purposes.
+		Transaction prevTx1 = new Transaction(params);
+		TransactionOutput prevOut1 = new TransactionOutput(params, prevTx1, Coin.valueOf(split), to);
+		prevTx1.addOutput(prevOut1);
+		// Connect it.
+		t.addInput(prevOut1).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+		// Fake signature.
 
-        // Serialize/deserialize to ensure internal state is stripped, as if it had been read from the wire.
-        return roundTripTransaction(params, t);
-    }
+		// Do it again
+		Transaction prevTx2 = new Transaction(params);
+		TransactionOutput prevOut2 = new TransactionOutput(params, prevTx2, Coin.valueOf(value.getValue() - split), to);
+		prevTx2.addOutput(prevOut2);
+		t.addInput(prevOut2).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
 
-    /**
-     * Create a fake TX of sufficient realism to exercise the unit tests. Two outputs, one to us, one to somewhere
-     * else to simulate change. There is one random input.
-     */
-    public static Transaction createFakeTx(NetworkParameters params, Coin value, Address to) {
-        return createFakeTxWithChangeAddress(params, value, to, new ECKey().toAddress(params));
-    }
+		// Serialize/deserialize to ensure internal state is stripped, as if it
+		// had been read from the wire.
+		return roundTripTransaction(params, t);
+	}
 
-    /**
-     * Create a fake TX of sufficient realism to exercise the unit tests. Two outputs, one to us, one to somewhere
-     * else to simulate change. There is one random input.
-     */
-    public static Transaction createFakeTx(NetworkParameters params, Coin value, ECKey to) {
-        Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
-        t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), new ECKey());
-        t.addOutput(change);
-        // Make a previous tx simply to send us sufficient coins. This prev tx is not really valid but it doesn't
-        // matter for our purposes.
-        Transaction prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
-        prevTx.addOutput(prevOut);
-        // Connect it.
-        t.addInput(prevOut);
-        // Serialize/deserialize to ensure internal state is stripped, as if it had been read from the wire.
-        return roundTripTransaction(params, t);
-    }
+	/**
+	 * Create a fake TX of sufficient realism to exercise the unit tests. Two
+	 * outputs, one to us, one to somewhere else to simulate change. There is
+	 * one random input.
+	 */
+	public static Transaction createFakeTx(NetworkParameters params, Coin value, Address to) {
+		return createFakeTxWithChangeAddress(params, value, to, new ECKey().toAddress(params));
+	}
 
-    /**
-     * Transaction[0] is a feeder transaction, supplying BTC to Transaction[1]
-     */
-    public static Transaction[] createFakeTx(NetworkParameters params, Coin value,
-                                             Address to, Address from) {
-        // Create fake TXes of sufficient realism to exercise the unit tests. This transaction send BTC from the
-        // from address, to the to address with to one to somewhere else to simulate change.
-        Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
-        t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), new ECKey().toAddress(params));
-        t.addOutput(change);
-        // Make a feeder tx that sends to the from address specified. This feeder tx is not really valid but it doesn't
-        // matter for our purposes.
-        Transaction feederTx = new Transaction(params);
-        TransactionOutput feederOut = new TransactionOutput(params, feederTx, value, from);
-        feederTx.addOutput(feederOut);
+	/**
+	 * Create a fake TX of sufficient realism to exercise the unit tests. Two
+	 * outputs, one to us, one to somewhere else to simulate change. There is
+	 * one random input.
+	 */
+	public static Transaction createFakeTx(NetworkParameters params, Coin value, ECKey to) {
+		Transaction t = new Transaction(params);
+		TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+		t.addOutput(outputToMe);
+		TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), new ECKey());
+		t.addOutput(change);
+		// Make a previous tx simply to send us sufficient coins. This prev tx
+		// is not really valid but it doesn't
+		// matter for our purposes.
+		Transaction prevTx = new Transaction(params);
+		TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
+		prevTx.addOutput(prevOut);
+		// Connect it.
+		t.addInput(prevOut);
+		// Serialize/deserialize to ensure internal state is stripped, as if it
+		// had been read from the wire.
+		return roundTripTransaction(params, t);
+	}
 
-        // make a previous tx that sends from the feeder to the from address
-        Transaction prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
-        prevTx.addOutput(prevOut);
+	/**
+	 * Transaction[0] is a feeder transaction, supplying BTC to Transaction[1]
+	 */
+	public static Transaction[] createFakeTx(NetworkParameters params, Coin value, Address to, Address from) {
+		// Create fake TXes of sufficient realism to exercise the unit tests.
+		// This transaction send BTC from the
+		// from address, to the to address with to one to somewhere else to
+		// simulate change.
+		Transaction t = new Transaction(params);
+		TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+		t.addOutput(outputToMe);
+		TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), new ECKey().toAddress(params));
+		t.addOutput(change);
+		// Make a feeder tx that sends to the from address specified. This
+		// feeder tx is not really valid but it doesn't
+		// matter for our purposes.
+		Transaction feederTx = new Transaction(params);
+		TransactionOutput feederOut = new TransactionOutput(params, feederTx, value, from);
+		feederTx.addOutput(feederOut);
 
-        // Connect up the txes
-        prevTx.addInput(feederOut);
-        t.addInput(prevOut);
+		// make a previous tx that sends from the feeder to the from address
+		Transaction prevTx = new Transaction(params);
+		TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
+		prevTx.addOutput(prevOut);
 
-        // roundtrip the tx so that they are just like they would be from the wire
-        return new Transaction[]{roundTripTransaction(params, prevTx), roundTripTransaction(params,t)};
-    }
+		// Connect up the txes
+		prevTx.addInput(feederOut);
+		t.addInput(prevOut);
 
-    /**
-     * Roundtrip a transaction so that it appears as if it has just come from the wire
-     */
-    public static Transaction roundTripTransaction(NetworkParameters params, Transaction tx) {
-        try {
-            MessageSerializer bs = params.getDefaultSerializer();
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            bs.serialize(tx, bos);
-            return (Transaction) bs.deserialize(ByteBuffer.wrap(bos.toByteArray()));
-        } catch (IOException e) {
-            throw new RuntimeException(e);   // Should not happen.
-        }
-    }
+		// roundtrip the tx so that they are just like they would be from the
+		// wire
+		return new Transaction[] { roundTripTransaction(params, prevTx), roundTripTransaction(params, t) };
+	}
 
-    public static class DoubleSpends {
-        public Transaction t1, t2, prevTx;
-    }
+	/**
+	 * Roundtrip a transaction so that it appears as if it has just come from
+	 * the wire
+	 */
+	public static Transaction roundTripTransaction(NetworkParameters params, Transaction tx) {
+		try {
+			MessageSerializer bs = params.getDefaultSerializer();
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			bs.serialize(tx, bos);
+			return (Transaction) bs.deserialize(ByteBuffer.wrap(bos.toByteArray()));
+		} catch (IOException e) {
+			throw new RuntimeException(e); // Should not happen.
+		}
+	}
 
-    /**
-     * Creates two transactions that spend the same (fake) output. t1 spends to "to". t2 spends somewhere else.
-     * The fake output goes to the same address as t2.
-     */
-    public static DoubleSpends createFakeDoubleSpendTxns(NetworkParameters params, Address to) {
-        DoubleSpends doubleSpends = new DoubleSpends();
-        Coin value = COIN;
-        Address someBadGuy = new ECKey().toAddress(params);
+	public static class DoubleSpends {
+		public Transaction t1, t2, prevTx;
+	}
 
-        doubleSpends.prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, doubleSpends.prevTx, value, someBadGuy);
-        doubleSpends.prevTx.addOutput(prevOut);
+	/**
+	 * Creates two transactions that spend the same (fake) output. t1 spends to
+	 * "to". t2 spends somewhere else. The fake output goes to the same address
+	 * as t2.
+	 */
+	public static DoubleSpends createFakeDoubleSpendTxns(NetworkParameters params, Address to) {
+		DoubleSpends doubleSpends = new DoubleSpends();
+		Coin value = COIN;
+		Address someBadGuy = new ECKey().toAddress(params);
 
-        doubleSpends.t1 = new Transaction(params);
-        TransactionOutput o1 = new TransactionOutput(params, doubleSpends.t1, value, to);
-        doubleSpends.t1.addOutput(o1);
-        doubleSpends.t1.addInput(prevOut);
+		doubleSpends.prevTx = new Transaction(params);
+		TransactionOutput prevOut = new TransactionOutput(params, doubleSpends.prevTx, value, someBadGuy);
+		doubleSpends.prevTx.addOutput(prevOut);
 
-        doubleSpends.t2 = new Transaction(params);
-        doubleSpends.t2.addInput(prevOut);
-        TransactionOutput o2 = new TransactionOutput(params, doubleSpends.t2, value, someBadGuy);
-        doubleSpends.t2.addOutput(o2);
+		doubleSpends.t1 = new Transaction(params);
+		TransactionOutput o1 = new TransactionOutput(params, doubleSpends.t1, value, to);
+		doubleSpends.t1.addOutput(o1);
+		doubleSpends.t1.addInput(prevOut);
 
-        try {
-            doubleSpends.t1 = params.getDefaultSerializer().makeTransaction(doubleSpends.t1.bitcoinSerialize());
-            doubleSpends.t2 = params.getDefaultSerializer().makeTransaction(doubleSpends.t2.bitcoinSerialize());
-        } catch (ProtocolException e) {
-            throw new RuntimeException(e);
-        }
-        return doubleSpends;
-    }
+		doubleSpends.t2 = new Transaction(params);
+		doubleSpends.t2.addInput(prevOut);
+		TransactionOutput o2 = new TransactionOutput(params, doubleSpends.t2, value, someBadGuy);
+		doubleSpends.t2.addOutput(o2);
 
-    public static class BlockPair {
-        public StoredBlock storedBlock;
-        public Block block;
-    }
+		try {
+			doubleSpends.t1 = params.getDefaultSerializer().makeTransaction(doubleSpends.t1.bitcoinSerialize());
+			doubleSpends.t2 = params.getDefaultSerializer().makeTransaction(doubleSpends.t2.bitcoinSerialize());
+		} catch (ProtocolException e) {
+			throw new RuntimeException(e);
+		}
+		return doubleSpends;
+	}
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
-    public static BlockPair createFakeBlock(BlockStore blockStore, long version,
-                                            long timeSeconds, Transaction... transactions) {
-        return createFakeBlock(blockStore, version, timeSeconds, 0, transactions);
-    }
+	public static class BlockPair {
+		public StoredBlock storedBlock;
+		public Block block;
+	}
 
-    /** Emulates receiving a valid block */
-    public static BlockPair createFakeBlock(BlockStore blockStore, StoredBlock previousStoredBlock, long version,
-                                            long timeSeconds, int height,
-                                            Transaction... transactions) {
-        try {
-            Block previousBlock = previousStoredBlock.getHeader();
-            Address to = new ECKey().toAddress(previousBlock.getParams());
-            Block b = previousBlock.createNextBlock(to, version, timeSeconds, height);
-            // Coinbase tx was already added.
-            for (Transaction tx : transactions) {
-                tx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
-                b.addTransaction(tx);
-            }
-            b.solve();
-            BlockPair pair = new BlockPair();
-            pair.block = b;
-            pair.storedBlock = previousStoredBlock.build(b);
-            blockStore.put(pair.storedBlock);
-            blockStore.setChainHead(pair.storedBlock);
-            return pair;
-        } catch (VerificationException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        } catch (BlockStoreException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        }
-    }
+	/** Emulates receiving a valid block that builds on top of the chain. */
+	public static BlockPair createFakeBlock(BlockStore blockStore, long version, long timeSeconds,
+			Transaction... transactions) {
+		return createFakeBlock(blockStore, version, timeSeconds, 0, transactions);
+	}
 
-    public static BlockPair createFakeBlock(BlockStore blockStore, StoredBlock previousStoredBlock, int height, Transaction... transactions) {
-        return createFakeBlock(blockStore, previousStoredBlock, Block.BLOCK_VERSION_BIP66, Utils.currentTimeSeconds(), height, transactions);
-    }
+	/** Emulates receiving a valid block */
+	public static BlockPair createFakeBlock(BlockStore blockStore, StoredBlock previousStoredBlock, long version,
+			long timeSeconds, int height, Transaction... transactions) {
+		try {
+			Block previousBlock = previousStoredBlock.getHeader();
+			Address to = new ECKey().toAddress(previousBlock.getParams());
+			Block b = previousBlock.createNextBlock(to, version, timeSeconds, height);
+			// Coinbase tx was already added.
+			for (Transaction tx : transactions) {
+				tx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
+				b.addTransaction(tx);
+			}
+			b.solve();
+			BlockPair pair = new BlockPair();
+			pair.block = b;
+			pair.storedBlock = previousStoredBlock.build(b);
+			blockStore.put(pair.storedBlock);
+			blockStore.setChainHead(pair.storedBlock);
+			return pair;
+		} catch (VerificationException e) {
+			throw new RuntimeException(e); // Cannot happen.
+		} catch (BlockStoreException e) {
+			throw new RuntimeException(e); // Cannot happen.
+		}
+	}
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
-    public static BlockPair createFakeBlock(BlockStore blockStore, long version, long timeSeconds, int height, Transaction... transactions) {
-        try {
-            return createFakeBlock(blockStore, blockStore.getChainHead(), version, timeSeconds, height, transactions);
-        } catch (BlockStoreException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        }
-    }
+	public static BlockPair createFakeBlock(BlockStore blockStore, StoredBlock previousStoredBlock, int height,
+			Transaction... transactions) {
+		return createFakeBlock(blockStore, previousStoredBlock, Block.BLOCK_VERSION_BIP66, Utils.currentTimeSeconds(),
+				height, transactions);
+	}
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
-    public static BlockPair createFakeBlock(BlockStore blockStore, int height,
-                                            Transaction... transactions) {
-        return createFakeBlock(blockStore, Block.BLOCK_VERSION_GENESIS, Utils.currentTimeSeconds(), height, transactions);
-    }
+	/** Emulates receiving a valid block that builds on top of the chain. */
+	public static BlockPair createFakeBlock(BlockStore blockStore, long version, long timeSeconds, int height,
+			Transaction... transactions) {
+		try {
+			return createFakeBlock(blockStore, blockStore.getChainHead(), version, timeSeconds, height, transactions);
+		} catch (BlockStoreException e) {
+			throw new RuntimeException(e); // Cannot happen.
+		}
+	}
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
-    public static BlockPair createFakeBlock(BlockStore blockStore, Transaction... transactions) {
-        return createFakeBlock(blockStore, Block.BLOCK_VERSION_GENESIS, Utils.currentTimeSeconds(), 0, transactions);
-    }
+	/** Emulates receiving a valid block that builds on top of the chain. */
+	public static BlockPair createFakeBlock(BlockStore blockStore, int height, Transaction... transactions) {
+		return createFakeBlock(blockStore, Block.BLOCK_VERSION_GENESIS, Utils.currentTimeSeconds(), height,
+				transactions);
+	}
 
-    public static Block makeSolvedTestBlock(BlockStore blockStore, Address coinsTo) throws BlockStoreException {
-        Block b = blockStore.getChainHead().getHeader().createNextBlock(coinsTo);
-        b.solve();
-        return b;
-    }
+	/** Emulates receiving a valid block that builds on top of the chain. */
+	public static BlockPair createFakeBlock(BlockStore blockStore, Transaction... transactions) {
+		return createFakeBlock(blockStore, Block.BLOCK_VERSION_GENESIS, Utils.currentTimeSeconds(), 0, transactions);
+	}
 
-    public static Block makeSolvedTestBlock(Block prev, Transaction... transactions) throws BlockStoreException {
-        Address to = new ECKey().toAddress(prev.getParams());
-        Block b = prev.createNextBlock(to);
-        // Coinbase tx already exists.
-        for (Transaction tx : transactions) {
-            b.addTransaction(tx);
-        }
-        b.solve();
-        return b;
-    }
+	public static Block makeSolvedTestBlock(BlockStore blockStore, Address coinsTo) throws BlockStoreException {
+		Block b = blockStore.getChainHead().getHeader().createNextBlock(coinsTo);
+		b.solve();
+		return b;
+	}
 
-    public static Block makeSolvedTestBlock(Block prev, Address to, Transaction... transactions) throws BlockStoreException {
-        Block b = prev.createNextBlock(to);
-        // Coinbase tx already exists.
-        for (Transaction tx : transactions) {
-            b.addTransaction(tx);
-        }
-        b.solve();
-        return b;
-    }
+	public static Block makeSolvedTestBlock(Block prev, Transaction... transactions) throws BlockStoreException {
+		Address to = new ECKey().toAddress(prev.getParams());
+		Block b = prev.createNextBlock(to);
+		// Coinbase tx already exists.
+		for (Transaction tx : transactions) {
+			b.addTransaction(tx);
+		}
+		b.solve();
+		return b;
+	}
+
+	public static Block makeSolvedTestBlock(Block prev, Address to, Transaction... transactions)
+			throws BlockStoreException {
+		Block b = prev.createNextBlock(to);
+		// Coinbase tx already exists.
+		for (Transaction tx : transactions) {
+			b.addTransaction(tx);
+		}
+		b.solve();
+		return b;
+	}
 }

--- a/src/test/java/com/coinblesk/server/utilTest/KeyTestUtil.java
+++ b/src/test/java/com/coinblesk/server/utilTest/KeyTestUtil.java
@@ -24,13 +24,13 @@ public class KeyTestUtil {
 	 */
 	public static final ECKey ALICE_CLIENT = ECKey.fromPrivate(Sha256Hash.hash("alice-client".getBytes()));
 	public static final ECKey ALICE_SERVER = ECKey.fromPrivate(Sha256Hash.hash("alice-server".getBytes()));
-	
+
 	public static final ECKey BOB_CLIENT = ECKey.fromPrivate(Sha256Hash.hash("bob-client".getBytes()));
 	public static final ECKey BOB_SERVER = ECKey.fromPrivate(Sha256Hash.hash("bob-server".getBytes()));
 
 	public static final ECKey CAROL_CLIENT = ECKey.fromPrivate(Sha256Hash.hash("carol-client".getBytes()));
 	public static final ECKey CAROL_SERVER = ECKey.fromPrivate(Sha256Hash.hash("carol-server".getBytes()));
-	
+
 	public static final ECKey DAVE_CLIENT = ECKey.fromPrivate(Sha256Hash.hash("dave-client".getBytes()));
 	public static final ECKey DAVE_SERVER = ECKey.fromPrivate(Sha256Hash.hash("dave-server".getBytes()));
 }

--- a/src/test/java/com/coinblesk/server/utilTest/RESTUtils.java
+++ b/src/test/java/com/coinblesk/server/utilTest/RESTUtils.java
@@ -33,24 +33,24 @@ public final class RESTUtils {
 	private RESTUtils() {
 		// prevent instance
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static <T extends BaseTO<?>> T postRequest(MockMvc mockMvc, String url, T requestTO) throws Exception {
 		String requestJSON = SerializeUtils.GSON.toJson(requestTO);
 		return (T) postRequest(mockMvc, url, requestJSON, requestTO.getClass());
 	}
-	
+
 	public static <T> T postRequest(MockMvc mockMvc, String url, String requestJSON, Class<T> responseClass) throws Exception {
-    	final MvcResult res = mockMvc
+		final MvcResult res = mockMvc
 				.perform(
 						post(url)
 						.secure(true)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(requestJSON))
-				.andExpect(status().isOk())
-				.andReturn();
-    	final String responseJson = res.getResponse().getContentAsString();
-    	final T responseTO = SerializeUtils.GSON.fromJson(responseJson, responseClass);
+						.andExpect(status().isOk())
+						.andReturn();
+		final String responseJson = res.getResponse().getContentAsString();
+		final T responseTO = SerializeUtils.GSON.fromJson(responseJson, responseClass);
 		return responseTO;
 	}
 }

--- a/src/test/java/com/coinblesk/server/utilTest/ServerCalls.java
+++ b/src/test/java/com/coinblesk/server/utilTest/ServerCalls.java
@@ -91,21 +91,24 @@ public class ServerCalls {
 	public static RefundTO refundServerCallInput(NetworkParameters params, ECKey client,
 			List<Pair<TransactionOutPoint, Coin>> refundClientOutpoints,
 			List<TransactionSignature> partiallySignedRefundClient, Date date, long lockTimeSeconds) throws Exception {
-		RefundTO refundP2shTO = new RefundTO()	.publicKey(client.getPubKey())
-												.outpointsCoinPair(
-														SerializeUtils.serializeOutPointsCoin(refundClientOutpoints))
-												.clientSignatures(
-														SerializeUtils.serializeSignatures(partiallySignedRefundClient))
-												.refundSendTo(client.toAddress(params).toString())
-												.lockTimeSeconds(lockTimeSeconds)
-												.currentDate(date.getTime());
+		RefundTO refundP2shTO = new RefundTO()
+				.publicKey(client.getPubKey())
+				.outpointsCoinPair(SerializeUtils.serializeOutPointsCoin(refundClientOutpoints))
+				.clientSignatures(SerializeUtils.serializeSignatures(partiallySignedRefundClient))
+				.refundSendTo(client.toAddress(params).toString())
+				.lockTimeSeconds(lockTimeSeconds)
+				.currentDate(date.getTime());
 		SerializeUtils.signJSON(refundP2shTO, client);
 		return refundP2shTO;
 	}
 
 	public static RefundTO refundServerCallOutput(MockMvc mockMvc, RefundTO refundP2shTO) throws Exception {
-		MvcResult res = mockMvc.perform(post("/payment/refund").secure(true).contentType(MediaType.APPLICATION_JSON).content(
-				SerializeUtils.GSON.toJson(refundP2shTO))).andExpect(status().isOk()).andReturn();
+		MvcResult res = mockMvc.perform(
+				post("/payment/refund")
+				.secure(true)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(SerializeUtils.GSON.toJson(refundP2shTO)))
+			.andExpect(status().isOk()).andReturn();
 		return SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), RefundTO.class);
 	}
 
@@ -117,11 +120,12 @@ public class ServerCalls {
 
 	public static SignTO signServerCallInput(List<Pair<byte[], Long>> outpointCoinPair, Address to, long amount,
 			ECKey client, Date date) throws Exception {
-		SignTO prepareHalfSignTO = new SignTO()	.outpointsCoinPair(outpointCoinPair)
-												.amountToSpend(amount)
-												.p2shAddressTo(to.toString())
-												.publicKey(client.getPubKey())
-												.currentDate(date.getTime());
+		SignTO prepareHalfSignTO = new SignTO()
+				.outpointsCoinPair(outpointCoinPair)
+				.amountToSpend(amount)
+				.p2shAddressTo(to.toString())
+				.publicKey(client.getPubKey())
+				.currentDate(date.getTime());
 		SerializeUtils.signJSON(prepareHalfSignTO, client);
 		return prepareHalfSignTO;
 	}
@@ -132,9 +136,10 @@ public class ServerCalls {
 	}
 
 	public static SignTO signServerCallInput(Transaction tx, ECKey client, Date date) throws Exception {
-		SignTO prepareHalfSignTO = new SignTO()	.transaction(tx.unsafeBitcoinSerialize())
-												.publicKey(client.getPubKey())
-												.currentDate(date.getTime());
+		SignTO prepareHalfSignTO = new SignTO()
+				.transaction(tx.unsafeBitcoinSerialize())
+				.publicKey(client.getPubKey())
+				.currentDate(date.getTime());
 		SerializeUtils.signJSON(prepareHalfSignTO, client);
 		return prepareHalfSignTO;
 	}

--- a/src/test/java/com/coinblesk/server/utilTest/ServerCalls.java
+++ b/src/test/java/com/coinblesk/server/utilTest/ServerCalls.java
@@ -5,24 +5,30 @@
  */
 package com.coinblesk.server.utilTest;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+import java.util.List;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.crypto.TransactionSignature;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
 import com.coinblesk.json.v1.RefundTO;
 import com.coinblesk.json.v1.SignTO;
 import com.coinblesk.json.v1.TxSig;
 import com.coinblesk.json.v1.VerifyTO;
 import com.coinblesk.util.Pair;
 import com.coinblesk.util.SerializeUtils;
-import org.bitcoinj.core.*;
-import org.bitcoinj.crypto.TransactionSignature;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import java.io.UnsupportedEncodingException;
-import java.util.Date;
-import java.util.List;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  *
@@ -69,7 +75,7 @@ public class ServerCalls {
 	}
 
 	public static VerifyTO verifyServerCallOutput(MockMvc mockMvc, VerifyTO cs) throws Exception {
-		MvcResult res = mockMvc.perform(post("/v2/p/v").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+		MvcResult res = mockMvc.perform(post("/v2/payment/verify").secure(true).contentType(MediaType.APPLICATION_JSON).content(
 				SerializeUtils.GSON.toJson(cs))).andExpect(status().isOk()).andReturn();
 		return SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), VerifyTO.class);
 	}
@@ -98,7 +104,7 @@ public class ServerCalls {
 	}
 
 	public static RefundTO refundServerCallOutput(MockMvc mockMvc, RefundTO refundP2shTO) throws Exception {
-		MvcResult res = mockMvc.perform(post("/p/r").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+		MvcResult res = mockMvc.perform(post("/payment/refund").secure(true).contentType(MediaType.APPLICATION_JSON).content(
 				SerializeUtils.GSON.toJson(refundP2shTO))).andExpect(status().isOk()).andReturn();
 		return SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), RefundTO.class);
 	}
@@ -134,7 +140,7 @@ public class ServerCalls {
 	}
 
 	public static SignTO signServerCallOutput(MockMvc mockMvc, SignTO prepareHalfSignTO) throws Exception {
-		MvcResult res = mockMvc.perform(post("/v2/p/s").secure(true).contentType(MediaType.APPLICATION_JSON).content(
+		MvcResult res = mockMvc.perform(post("/v2/payment/sign").secure(true).contentType(MediaType.APPLICATION_JSON).content(
 				SerializeUtils.GSON.toJson(prepareHalfSignTO))).andExpect(status().isOk()).andReturn();
 		return SerializeUtils.GSON.fromJson(res.getResponse().getContentAsString(), SignTO.class);
 	}

--- a/src/test/java/com/coinblesk/server/utilTest/TestBean.java
+++ b/src/test/java/com/coinblesk/server/utilTest/TestBean.java
@@ -15,8 +15,8 @@ import javax.annotation.PostConstruct;
  */
 @Configuration
 public class TestBean {
-    @PostConstruct 
-    public void init() {
-        System.setProperty("db.injectCredentials", "false");
-    }
+	@PostConstruct
+	public void init() {
+		System.setProperty("db.injectCredentials", "false");
+	}
 }


### PR DESCRIPTION
I have removed all short forms of the REST interfaces to clean up the Swagger View (e.g. `/u/a/g`, `/w/x` etc.). I also formatted the whole project (Java code only) and fixed some formatting errors (mostly fluid API stuff). There are now two REST API groups `whole-api` and `non-v1-api`. The first one shows every single interface and the second one shows only empty and `v2+` interfaces. `non-v1-api` is the default.