### PR TITLE
remove white label error page

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -23,6 +23,9 @@ spring.datasource.url=jdbc:h2:mem:testdb
 #
 logging.level.root=INFO
 
+# Disable Whitelabel Default Error Page
+server.error.whitelabel.enabled = false
+
 # External URL of backend. Used for links in emails. Example:
 #
 #     coinblesk.url=https://coinblesk.csg.uzh.ch/

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -24,6 +24,9 @@ spring.datasource.url=jdbc:postgresql://localhost/coinblesk
 logging.level.root=WARN
 logging.level.com.coinblesk=INFO
 
+# Disable Whitelabel Default Error Page
+server.error.whitelabel.enabled = false
+
 # External URL of backend. Used for links in emails. Example:
 #
 #     coinblesk.url=https://coinblesk.csg.uzh.ch/


### PR DESCRIPTION
Removes the default page on the web server "Whitelabel Error Page". Now, it only shows a blank screen (with HTTP status 404 or 401, etc.).